### PR TITLE
Phase 1: align Angular 17 baseline for phased migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: "@angular/*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: npm
+    directory: "/e2e"
+    schedule:
+      interval: weekly

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Este projeto foi migrado de:
 - Hibernate Criteria API → JPA Criteria API
 - Spring Security 5 → Spring Security 6
 
+### Plano de migração faseada do Angular
+
+- Fase 1: alinhar todas as dependências do frontend na última base estável do Angular 17 e bloquear upgrades major automáticos parciais.
+- Fase 2: executar migração coordenada do Angular 17 para 18 com atualização conjunta de framework, CLI, builder e compiler-cli.
+- Fase 3: repetir o mesmo processo para 19+ apenas após build e testes verdes em cada etapa.
+
 ## Licença
 
 Este projeto é baseado no curso AlgaWorks e serve apenas para fins educacionais.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,21 +10,21 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^17.3.0",
-    "@angular/common": "^17.3.0",
-    "@angular/compiler": "^17.3.0",
-    "@angular/core": "^17.3.0",
-    "@angular/forms": "^17.3.0",
-    "@angular/platform-browser": "^17.3.0",
-    "@angular/platform-browser-dynamic": "^17.3.0",
-    "@angular/router": "^17.3.0",
+    "@angular/animations": "^17.3.12",
+    "@angular/common": "^17.3.12",
+    "@angular/compiler": "^17.3.12",
+    "@angular/core": "^17.3.12",
+    "@angular/forms": "^17.3.12",
+    "@angular/platform-browser": "^17.3.12",
+    "@angular/platform-browser-dynamic": "^17.3.12",
+    "@angular/router": "^17.3.12",
     "rxjs": "~7.8.0",
     "zone.js": "~0.14.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.3.0",
-    "@angular/cli": "^17.3.0",
-    "@angular/compiler-cli": "^17.3.0",
+    "@angular-devkit/build-angular": "^17.3.17",
+    "@angular/cli": "^17.3.17",
+    "@angular/compiler-cli": "^17.3.12",
     "@playwright/test": "^1.40.0",
     "typescript": "~5.3.0"
   }


### PR DESCRIPTION
## Objetivo
Criar a fase 1 da migracao Angular de forma segura, sem salto major parcial.

## O que este PR faz
- alinha o frontend para a ultima base estavel do Angular 17
- alinha CLI e builder na linha 17.x compativel
- adiciona configuracao do Dependabot para evitar PRs automaticos com upgrades major parciais de @angular/*
- documenta no README o plano de migracao em fases

## Validacao
- npm install --package-lock=false
- CI=1 NG_CLI_ANALYTICS=false npm run build

## Proximas fases
- fase 2: migracao coordenada Angular 17 -> 18
- fase 3: repetir o processo para 19+ com build e testes verdes em cada etapa
