### PR TITLE
Spike: validate OpenHTMLtoPDF for sales report replacement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 <artifactId>jackson-databind</artifactId>
 </dependency>
 
+<dependency>
+<groupId>com.openhtmltopdf</groupId>
+<artifactId>openhtmltopdf-pdfbox</artifactId>
+<version>1.0.10</version>
+</dependency>
+
 <!-- Apache Bean Utils -->
 <dependency>
 <groupId>commons-beanutils</groupId>

--- a/src/main/java/com/algaworks/brewer/Service/RelatorioHtmlPdfService.java
+++ b/src/main/java/com/algaworks/brewer/Service/RelatorioHtmlPdfService.java
@@ -1,0 +1,59 @@
+package com.algaworks.brewer.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import com.algaworks.brewer.dto.PeriodoRelatorio;
+import com.algaworks.brewer.dto.RelatorioVendaEmitidaItem;
+import com.algaworks.brewer.model.StatusVenda;
+import com.algaworks.brewer.repository.Vendas;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+
+@Service
+public class RelatorioHtmlPdfService {
+
+	private final Vendas vendas;
+	private final TemplateEngine templateEngine;
+
+	public RelatorioHtmlPdfService(Vendas vendas, TemplateEngine templateEngine) {
+		this.vendas = vendas;
+		this.templateEngine = templateEngine;
+	}
+
+	@Transactional(readOnly = true)
+	public byte[] gerarRelatorioVendasEmitidasSpike(PeriodoRelatorio periodoRelatorio) throws Exception {
+		LocalDateTime dataInicio = LocalDateTime.of(periodoRelatorio.getDataInicio(), LocalTime.of(0, 0, 0));
+		LocalDateTime dataFim = LocalDateTime.of(periodoRelatorio.getDataFim(), LocalTime.of(23, 59, 59));
+
+		List<RelatorioVendaEmitidaItem> vendasEmitidas = vendas.buscarEmitidasNoPeriodo(StatusVenda.EMITIDA, dataInicio,
+				dataFim);
+		BigDecimal valorTotal = vendasEmitidas.stream().map(RelatorioVendaEmitidaItem::getValorTotal)
+				.reduce(BigDecimal.ZERO, BigDecimal::add);
+
+		Context context = new Context();
+		context.setVariable("periodoRelatorio", periodoRelatorio);
+		context.setVariable("vendasEmitidas", vendasEmitidas);
+		context.setVariable("valorTotal", valorTotal);
+		context.setVariable("quantidadeVendas", vendasEmitidas.size());
+		context.setVariable("dataGeracao", LocalDateTime.now());
+
+		String html = templateEngine.process("relatorio/RelatorioVendasEmitidasSpikePdf", context);
+
+		try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+			PdfRendererBuilder builder = new PdfRendererBuilder();
+			builder.useFastMode();
+			builder.withHtmlContent(html, null);
+			builder.toStream(outputStream);
+			builder.run();
+			return outputStream.toByteArray();
+		}
+	}
+}

--- a/src/main/java/com/algaworks/brewer/config/H2DevelopmentDataInitializer.java
+++ b/src/main/java/com/algaworks/brewer/config/H2DevelopmentDataInitializer.java
@@ -1,0 +1,75 @@
+package com.algaworks.brewer.config;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@ConditionalOnProperty(name = "spring.datasource.driverClassName", havingValue = "org.h2.Driver")
+public class H2DevelopmentDataInitializer implements ApplicationRunner {
+
+	private static final String ADMIN_EMAIL = "admin@brewer.com";
+	private static final String ADMIN_PASSWORD_HASH = "$2a$10$x3dW.vGNa.OsxIBZ7qi36uScizK1I1UspCXjasBlnZ31k5yiw.KCa";
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public H2DevelopmentDataInitializer(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	@Transactional
+	public void run(ApplicationArguments args) {
+		seedGroups();
+		seedPermissions();
+		seedGroupPermissions();
+		seedAdminUser();
+		seedAdminGroupMembership();
+	}
+
+	private void seedGroups() {
+		jdbcTemplate.update("MERGE INTO grupo (codigo, nome) KEY(codigo) VALUES (?, ?)", 1L, "Administrador");
+		jdbcTemplate.update("MERGE INTO grupo (codigo, nome) KEY(codigo) VALUES (?, ?)", 2L, "Vendedor");
+	}
+
+	private void seedPermissions() {
+		jdbcTemplate.update("MERGE INTO permissao (codigo, nome) KEY(codigo) VALUES (?, ?)", 1L,
+				"ROLE_CADASTRAR_CIDADE");
+		jdbcTemplate.update("MERGE INTO permissao (codigo, nome) KEY(codigo) VALUES (?, ?)", 2L,
+				"ROLE_CADASTRAR_USUARIO");
+		jdbcTemplate.update("MERGE INTO permissao (codigo, nome) KEY(codigo) VALUES (?, ?)", 3L,
+				"ROLE_CANCELAR_VENDA");
+	}
+
+	private void seedGroupPermissions() {
+		mergeGroupPermission(1L, 1L);
+		mergeGroupPermission(1L, 2L);
+		mergeGroupPermission(1L, 3L);
+	}
+
+	private void seedAdminUser() {
+		jdbcTemplate.update(
+				"INSERT INTO usuario (nome, email, senha, ativo, data_nascimento) "
+						+ "SELECT ?, ?, ?, ?, DATE '1990-01-01' "
+						+ "WHERE NOT EXISTS (SELECT 1 FROM usuario WHERE email = ?)",
+				"Admin", ADMIN_EMAIL, ADMIN_PASSWORD_HASH, true, ADMIN_EMAIL);
+	}
+
+	private void seedAdminGroupMembership() {
+		jdbcTemplate.update(
+				"INSERT INTO usuario_grupo (codigo_usuario, codigo_grupo) "
+						+ "SELECT u.codigo, ? FROM usuario u "
+						+ "WHERE u.email = ? "
+						+ "AND NOT EXISTS (SELECT 1 FROM usuario_grupo ug WHERE ug.codigo_usuario = u.codigo AND ug.codigo_grupo = ?)",
+				1L, ADMIN_EMAIL, 1L);
+	}
+
+	private void mergeGroupPermission(Long groupId, Long permissionId) {
+		jdbcTemplate.update(
+				"MERGE INTO grupo_permissao (codigo_grupo, codigo_permissao) KEY(codigo_grupo, codigo_permissao) VALUES (?, ?)",
+				groupId, permissionId);
+	}
+}

--- a/src/main/java/com/algaworks/brewer/config/SecurityConfig.java
+++ b/src/main/java/com/algaworks/brewer/config/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig {
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
 			.authorizeHttpRequests(authorize -> authorize
+				.requestMatchers("/h2-console/**").permitAll()
 				.requestMatchers("/cidades/novo").hasRole("CADASTRAR_CIDADE")
 				.requestMatchers("/usuarios/**").hasRole("CADASTRAR_USUARIO")
 				.requestMatchers("/api/estados").permitAll()
@@ -43,7 +44,10 @@ public class SecurityConfig {
 				.invalidSessionUrl("/login")
 			)
 			.csrf(csrf -> csrf
-				.ignoringRequestMatchers("/api/**")
+				.ignoringRequestMatchers("/api/**", "/h2-console/**")
+			)
+			.headers(headers -> headers
+				.frameOptions(frame -> frame.sameOrigin())
 			);
 		
 		return http.build();

--- a/src/main/java/com/algaworks/brewer/controller/RelatoriosController.java
+++ b/src/main/java/com/algaworks/brewer/controller/RelatoriosController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
 
 import com.algaworks.brewer.Service.RelatorioService;
+import com.algaworks.brewer.Service.RelatorioHtmlPdfService;
 import com.algaworks.brewer.dto.PeriodoRelatorio;
 
 @Controller
@@ -21,6 +22,9 @@ public class RelatoriosController {
 	
 	@Autowired
 	private RelatorioService relatorioService;
+
+	@Autowired
+	private RelatorioHtmlPdfService relatorioHtmlPdfService;
 	
 	@GetMapping("/vendasEmitidas")
 	public ModelAndView relatorioVendasEmitidas() {
@@ -36,6 +40,15 @@ public class RelatoriosController {
 			
 		byte[] relatorio = relatorioService.gerarRelatorioVendasEmitidas(periodoRelatorio);
 		
+		return ResponseEntity.ok()
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_PDF_VALUE)
+				.body(relatorio);
+	}
+
+	@PostMapping("/vendasEmitidas/spike-html")
+	public ResponseEntity<byte[]> gerarRelatorioVendasEmitidasSpike(PeriodoRelatorio periodoRelatorio) throws Exception {
+		byte[] relatorio = relatorioHtmlPdfService.gerarRelatorioVendasEmitidasSpike(periodoRelatorio);
+
 		return ResponseEntity.ok()
 				.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_PDF_VALUE)
 				.body(relatorio);

--- a/src/main/java/com/algaworks/brewer/controller/RelatoriosController.java
+++ b/src/main/java/com/algaworks/brewer/controller/RelatoriosController.java
@@ -51,6 +51,7 @@ public class RelatoriosController {
 
 		return ResponseEntity.ok()
 				.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_PDF_VALUE)
+				.header("Content-Disposition", "inline; filename=relatorio-vendas-emitidas-spike.pdf")
 				.body(relatorio);
 	}
 

--- a/src/main/java/com/algaworks/brewer/dto/RelatorioVendaEmitidaItem.java
+++ b/src/main/java/com/algaworks/brewer/dto/RelatorioVendaEmitidaItem.java
@@ -1,0 +1,50 @@
+package com.algaworks.brewer.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import com.algaworks.brewer.model.StatusVenda;
+
+public class RelatorioVendaEmitidaItem {
+
+	private Long codigo;
+	private LocalDateTime dataCriacao;
+	private String nomeCliente;
+	private String nomeUsuario;
+	private BigDecimal valorTotal;
+	private StatusVenda status;
+
+	public RelatorioVendaEmitidaItem(Long codigo, LocalDateTime dataCriacao, String nomeCliente,
+			String nomeUsuario, BigDecimal valorTotal, StatusVenda status) {
+		this.codigo = codigo;
+		this.dataCriacao = dataCriacao;
+		this.nomeCliente = nomeCliente;
+		this.nomeUsuario = nomeUsuario;
+		this.valorTotal = valorTotal;
+		this.status = status;
+	}
+
+	public Long getCodigo() {
+		return codigo;
+	}
+
+	public LocalDateTime getDataCriacao() {
+		return dataCriacao;
+	}
+
+	public String getNomeCliente() {
+		return nomeCliente;
+	}
+
+	public String getNomeUsuario() {
+		return nomeUsuario;
+	}
+
+	public BigDecimal getValorTotal() {
+		return valorTotal;
+	}
+
+	public StatusVenda getStatus() {
+		return status;
+	}
+}

--- a/src/main/java/com/algaworks/brewer/repository/Vendas.java
+++ b/src/main/java/com/algaworks/brewer/repository/Vendas.java
@@ -1,12 +1,25 @@
 package com.algaworks.brewer.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.LocalDateTime;
+import java.util.List;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.algaworks.brewer.dto.RelatorioVendaEmitidaItem;
+import com.algaworks.brewer.model.StatusVenda;
 import com.algaworks.brewer.model.Venda;
 import com.algaworks.brewer.repository.helper.venda.VendasQueries;
 
 public interface Vendas extends JpaRepository<Venda, Long>, VendasQueries{
 
-	
+	@Query("select new com.algaworks.brewer.dto.RelatorioVendaEmitidaItem(" +
+			"v.codigo, v.dataCriacao, cliente.nome, usuario.nome, v.valorTotal, v.status) " +
+			"from Venda v join v.cliente cliente join v.usuario usuario " +
+			"where v.status = :status and v.dataCriacao between :dataInicio and :dataFim " +
+			"order by v.dataCriacao asc, v.codigo asc")
+	List<RelatorioVendaEmitidaItem> buscarEmitidasNoPeriodo(@Param("status") StatusVenda status,
+			@Param("dataInicio") LocalDateTime dataInicio, @Param("dataFim") LocalDateTime dataFim);
 
 }

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -109,7 +109,7 @@ cerveja.todosEstilos											= All styles
 #venda.cadastro
 
 venda.cadastro.titulo 											= Sales record
-venda.edicao.titulo 											= Issue of sale nº {0}
+venda.edicao.titulo 											= Issue of sale nï¿½ {0}
 venda.criacao													= Creation
 venda.cliente													= Client
 venda.valorFrete												= Cost of freight
@@ -253,4 +253,7 @@ usuario.statusInativo											= Inactive
 
 vendasEmitidas.titulo											= Report - Sales Issued
 vendasEmitidas.dataCriacao										= Creation date
+vendasEmitidas.spike.titulo								= Spike comparison:
+vendasEmitidas.spike.descricao							= the alternate button generates an HTML-based PDF for visual comparison with the current JasperReports output.
+vendasEmitidas.spike.botao								= Generate HTML spike
 

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -253,4 +253,7 @@ usuario.statusInativo											= Inativo
 
 vendasEmitidas.titulo											= Relatório - Vendas Emitidas
 vendasEmitidas.dataCriacao										= Data de criação
+vendasEmitidas.spike.titulo								= Comparativo do spike:
+vendasEmitidas.spike.descricao							= o botão alternativo gera um PDF em HTML para comparação visual com o relatório atual em JasperReports.
+vendasEmitidas.spike.botao								= Emitir spike HTML
 

--- a/src/main/resources/templates/relatorio/RelatorioVendasEmitidas.html
+++ b/src/main/resources/templates/relatorio/RelatorioVendasEmitidas.html
@@ -36,6 +36,9 @@
 			</div>
 				
 			<button type="submit" class="btn  btn-primary" th:text=#{btn.emitir}>Emitir</button>
+			<button type="submit" class="btn btn-default"
+				formaction="/relatorios/vendasEmitidas/spike-html"
+				formtarget="_blank">Emitir spike HTML</button>
 		</form>
 	</div>
 </section>

--- a/src/main/resources/templates/relatorio/RelatorioVendasEmitidas.html
+++ b/src/main/resources/templates/relatorio/RelatorioVendasEmitidas.html
@@ -21,6 +21,11 @@
 	<div class="container-fluid">
 		<form method="POST" th:object="${periodoRelatorio}" th:action="@{/relatorios/vendasEmitidas}" target="_blank">
 			<th:block th:include="fragments/MensagensErroValidacao"></th:block>
+
+			<div class="alert alert-warning">
+				<strong th:text="#{vendasEmitidas.spike.titulo}">Comparativo do spike</strong>
+				<span th:text="#{vendasEmitidas.spike.descricao}">O botao do spike gera um PDF alternativo em HTML para comparacao visual com o Jasper atual.</span>
+			</div>
 			
 			<div class="row">
 				<div class="form-group  col-sm-12">
@@ -38,7 +43,7 @@
 			<button type="submit" class="btn  btn-primary" th:text=#{btn.emitir}>Emitir</button>
 			<button type="submit" class="btn btn-default"
 				formaction="/relatorios/vendasEmitidas/spike-html"
-				formtarget="_blank">Emitir spike HTML</button>
+				formtarget="_blank" th:text="#{vendasEmitidas.spike.botao}">Emitir spike HTML</button>
 		</form>
 	</div>
 </section>

--- a/src/main/resources/templates/relatorio/RelatorioVendasEmitidasSpikePdf.html
+++ b/src/main/resources/templates/relatorio/RelatorioVendasEmitidasSpikePdf.html
@@ -4,21 +4,42 @@
 	<meta charset="UTF-8" />
 	<title>Spike - Relatorio de vendas emitidas</title>
 	<style>
+		@page {
+			size: A4;
+			margin: 20mm 14mm 18mm;
+		}
+
 		body {
 			font-family: Helvetica, Arial, sans-serif;
 			font-size: 12px;
 			color: #1f2933;
-			margin: 24px;
+			margin: 0;
 		}
 
-		h1 {
-			font-size: 22px;
-			margin-bottom: 8px;
+		.header {
+			border-bottom: 2px solid #102a43;
+			padding-bottom: 12px;
+			margin-bottom: 18px;
+		}
+
+		.header-title {
+			font-size: 24px;
+			font-weight: bold;
+			color: #102a43;
+			margin: 0 0 4px;
+		}
+
+		.header-subtitle {
+			font-size: 12px;
+			color: #486581;
+			margin: 0;
 		}
 
 		.meta {
-			margin-bottom: 18px;
+			margin: 14px 0 18px;
 			color: #52606d;
+			font-size: 11px;
+			line-height: 1.6;
 		}
 
 		.summary {
@@ -28,13 +49,28 @@
 		}
 
 		.summary td {
-			padding: 8px 10px;
+			padding: 10px 12px;
 			border: 1px solid #d9e2ec;
+			background: #f8fbff;
+		}
+
+		.summary-label {
+			font-size: 10px;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+			color: #7b8794;
+		}
+
+		.summary-value {
+			font-size: 16px;
+			font-weight: bold;
+			color: #102a43;
 		}
 
 		table.report {
 			width: 100%;
 			border-collapse: collapse;
+			table-layout: fixed;
 		}
 
 		table.report th {
@@ -43,14 +79,28 @@
 			text-align: left;
 			padding: 8px 10px;
 			font-size: 11px;
+			text-transform: uppercase;
 		}
 
 		table.report td {
 			padding: 8px 10px;
 			border-bottom: 1px solid #d9e2ec;
+			vertical-align: top;
+			word-wrap: break-word;
+		}
+
+		table.report tbody tr:nth-child(even) td {
+			background: #f8fbff;
 		}
 
 		.text-right {
+			text-align: right;
+		}
+
+		.footer {
+			margin-top: 18px;
+			font-size: 10px;
+			color: #7b8794;
 			text-align: right;
 		}
 
@@ -63,19 +113,27 @@
 	</style>
 </head>
 <body>
-	<h1>Spike HTML para PDF - Vendas Emitidas</h1>
+	<div class="header">
+		<div class="header-title">Relatorio de vendas emitidas</div>
+		<div class="header-subtitle">Spike HTML para comparacao com o fluxo JasperReports</div>
+	</div>
+
 	<div class="meta">
-		<div>Periodo: <span th:text="${#temporals.format(periodoRelatorio.dataInicio, 'dd/MM/yyyy')}">01/01/2026</span>
-			ate <span th:text="${#temporals.format(periodoRelatorio.dataFim, 'dd/MM/yyyy')}">31/01/2026</span></div>
+		<div>Periodo analisado: <strong th:text="${#temporals.format(periodoRelatorio.dataInicio, 'dd/MM/yyyy')}">01/01/2026</strong>
+			ate <strong th:text="${#temporals.format(periodoRelatorio.dataFim, 'dd/MM/yyyy')}">31/01/2026</strong></div>
 		<div>Gerado em: <span th:text="${#temporals.format(dataGeracao, 'dd/MM/yyyy HH:mm')}">08/04/2026 10:30</span></div>
 	</div>
 
 	<table class="summary">
 		<tr>
-			<td>Quantidade de vendas</td>
-			<td class="text-right" th:text="${quantidadeVendas}">0</td>
-			<td>Valor total</td>
-			<td class="text-right" th:text="${#numbers.formatDecimal(valorTotal, 1, 'POINT', 2, 'COMMA')}">0,00</td>
+			<td>
+				<div class="summary-label">Quantidade de vendas</div>
+				<div class="summary-value" th:text="${quantidadeVendas}">0</div>
+			</td>
+			<td>
+				<div class="summary-label">Valor total emitido</div>
+				<div class="summary-value" th:text="|R$ ${#numbers.formatDecimal(valorTotal, 1, 'POINT', 2, 'COMMA')}|">R$ 0,00</div>
+			</td>
 		</tr>
 	</table>
 
@@ -98,13 +156,17 @@
 				<td th:text="${venda.nomeUsuario}">Usuario</td>
 				<td th:text="${venda.status.descricao}">Emitida</td>
 				<td class="text-right"
-					th:text="${#numbers.formatDecimal(venda.valorTotal, 1, 'POINT', 2, 'COMMA')}">0,00</td>
+					th:text="|R$ ${#numbers.formatDecimal(venda.valorTotal, 1, 'POINT', 2, 'COMMA')}|">R$ 0,00</td>
 			</tr>
 		</tbody>
 	</table>
 
 	<div class="empty" th:if="${#lists.isEmpty(vendasEmitidas)}">
 		Nenhuma venda emitida encontrada para o periodo informado.
+	</div>
+
+	<div class="footer">
+		Documento gerado pelo spike HTML para avaliacao de substituicao do JasperReports.
 	</div>
 </body>
 </html>

--- a/src/main/resources/templates/relatorio/RelatorioVendasEmitidasSpikePdf.html
+++ b/src/main/resources/templates/relatorio/RelatorioVendasEmitidasSpikePdf.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="UTF-8" />
+	<title>Spike - Relatorio de vendas emitidas</title>
+	<style>
+		body {
+			font-family: Helvetica, Arial, sans-serif;
+			font-size: 12px;
+			color: #1f2933;
+			margin: 24px;
+		}
+
+		h1 {
+			font-size: 22px;
+			margin-bottom: 8px;
+		}
+
+		.meta {
+			margin-bottom: 18px;
+			color: #52606d;
+		}
+
+		.summary {
+			width: 100%;
+			margin: 16px 0 20px;
+			border-collapse: collapse;
+		}
+
+		.summary td {
+			padding: 8px 10px;
+			border: 1px solid #d9e2ec;
+		}
+
+		table.report {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		table.report th {
+			background: #102a43;
+			color: #f0f4f8;
+			text-align: left;
+			padding: 8px 10px;
+			font-size: 11px;
+		}
+
+		table.report td {
+			padding: 8px 10px;
+			border-bottom: 1px solid #d9e2ec;
+		}
+
+		.text-right {
+			text-align: right;
+		}
+
+		.empty {
+			padding: 18px;
+			text-align: center;
+			color: #7b8794;
+			border: 1px solid #d9e2ec;
+		}
+	</style>
+</head>
+<body>
+	<h1>Spike HTML para PDF - Vendas Emitidas</h1>
+	<div class="meta">
+		<div>Periodo: <span th:text="${#temporals.format(periodoRelatorio.dataInicio, 'dd/MM/yyyy')}">01/01/2026</span>
+			ate <span th:text="${#temporals.format(periodoRelatorio.dataFim, 'dd/MM/yyyy')}">31/01/2026</span></div>
+		<div>Gerado em: <span th:text="${#temporals.format(dataGeracao, 'dd/MM/yyyy HH:mm')}">08/04/2026 10:30</span></div>
+	</div>
+
+	<table class="summary">
+		<tr>
+			<td>Quantidade de vendas</td>
+			<td class="text-right" th:text="${quantidadeVendas}">0</td>
+			<td>Valor total</td>
+			<td class="text-right" th:text="${#numbers.formatDecimal(valorTotal, 1, 'POINT', 2, 'COMMA')}">0,00</td>
+		</tr>
+	</table>
+
+	<table class="report" th:if="${!#lists.isEmpty(vendasEmitidas)}">
+		<thead>
+			<tr>
+				<th>Codigo</th>
+				<th>Data</th>
+				<th>Cliente</th>
+				<th>Usuario</th>
+				<th>Status</th>
+				<th class="text-right">Valor total</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr th:each="venda : ${vendasEmitidas}">
+				<td th:text="${venda.codigo}">1</td>
+				<td th:text="${#temporals.format(venda.dataCriacao, 'dd/MM/yyyy HH:mm')}">08/04/2026 10:30</td>
+				<td th:text="${venda.nomeCliente}">Cliente</td>
+				<td th:text="${venda.nomeUsuario}">Usuario</td>
+				<td th:text="${venda.status.descricao}">Emitida</td>
+				<td class="text-right"
+					th:text="${#numbers.formatDecimal(venda.valorTotal, 1, 'POINT', 2, 'COMMA')}">0,00</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<div class="empty" th:if="${#lists.isEmpty(vendasEmitidas)}">
+		Nenhuma venda emitida encontrada para o periodo informado.
+	</div>
+</body>
+</html>


### PR DESCRIPTION
## Objetivo
Validar a substituicao do JasperReports por HTML + Thymeleaf + OpenHTMLtoPDF em um caminho paralelo, sem mexer ainda no endpoint atual de producao.

## O que este PR faz
- adiciona OpenHTMLtoPDF ao backend
- cria uma consulta dedicada para listar vendas emitidas no periodo
- cria um servico paralelo para renderizar PDF a partir de template HTML
- adiciona um endpoint separado para o spike
- adiciona um template de PDF em HTML/Thymeleaf
- adiciona um botao de teste na tela atual para comparar a saida com o fluxo Jasper

## Validacao
- mvn test

## Observacoes
- o endpoint Jasper atual foi mantido intacto
- este PR e um spike tecnico para avaliacao de viabilidade e comparacao visual
- o proximo passo natural e ajustar o layout HTML ate atingir paridade suficiente com o relatorio atual
