### PR TITLE
Fix Spring MVC binding and local storage defaults

### DIFF
--- a/src/main/java/com/algaworks/brewer/config/WebConfig.java
+++ b/src/main/java/com/algaworks/brewer/config/WebConfig.java
@@ -14,10 +14,8 @@ import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource;
-import org.springframework.data.repository.support.DomainClassConverter;
 import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
-import org.springframework.format.support.DefaultFormattingConversionService;
-import org.springframework.format.support.FormattingConversionService;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.validation.Validator;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.servlet.ViewResolver;
@@ -97,27 +95,24 @@ public class WebConfig implements ApplicationContextAware, WebMvcConfigurer {
 			.allowCredentials(true);
 	}
 
-	@Bean
-	public FormattingConversionService mvcConversionService() {
-		DefaultFormattingConversionService conversionService = new DefaultFormattingConversionService();
-		conversionService.addConverter(new EstiloConverter());
-		conversionService.addConverter(new CidadeConverter());
-		conversionService.addConverter(new EstadoConverter());
-		conversionService.addConverter(new GrupoConverter());
+	@Override
+	public void addFormatters(FormatterRegistry registry) {
+		registry.addConverter(new EstiloConverter());
+		registry.addConverter(new CidadeConverter());
+		registry.addConverter(new EstadoConverter());
+		registry.addConverter(new GrupoConverter());
 
 		BigDecimalFormatter bigDecimalFormatter = new BigDecimalFormatter("#,##0.00");
-		conversionService.addFormatterForFieldType(BigDecimal.class, bigDecimalFormatter);
+		registry.addFormatterForFieldType(BigDecimal.class, bigDecimalFormatter);
 
 		BigDecimalFormatter integerFormatter = new BigDecimalFormatter("#,##0");
-		conversionService.addFormatterForFieldType(Integer.class, integerFormatter);
+		registry.addFormatterForFieldType(Integer.class, integerFormatter);
 
 		// Api de datas do Java
 		DateTimeFormatterRegistrar dateTimeFormatter = new DateTimeFormatterRegistrar();
 		dateTimeFormatter.setDateFormatter(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
 		dateTimeFormatter.setTimeFormatter(DateTimeFormatter.ofPattern("HH:mm"));
-		dateTimeFormatter.registerFormatters(conversionService);
-
-		return conversionService;
+		dateTimeFormatter.registerFormatters(registry);
 	}
 
 	@Bean
@@ -133,11 +128,6 @@ public class WebConfig implements ApplicationContextAware, WebMvcConfigurer {
 		bundle.setBasename("classpath:/messages");
 		bundle.setDefaultEncoding("UTF-8");
 		return bundle;
-	}
-
-	@Bean
-	public DomainClassConverter<?> domainClassConverter() {
-		return new DomainClassConverter<FormattingConversionService>(mvcConversionService());
 	}
 
 	@Bean

--- a/src/main/java/com/algaworks/brewer/controller/CervejasController.java
+++ b/src/main/java/com/algaworks/brewer/controller/CervejasController.java
@@ -55,7 +55,7 @@ public class CervejasController {
 		return mv;
 	}
 
-	@PostMapping(value = {"/nova", "{\\d+}"})
+	@PostMapping(value = {"/nova", "/{codigo}"})
 	public ModelAndView salvar(@Valid Cerveja cerveja, BindingResult result, Model model,
 			RedirectAttributes attributes) {
 		if (result.hasErrors()) {		

--- a/src/main/java/com/algaworks/brewer/controller/CidadesController.java
+++ b/src/main/java/com/algaworks/brewer/controller/CidadesController.java
@@ -66,7 +66,7 @@ public class CidadesController {
 	}
 	
 	//@Secured("ROLE_CADASTRAR_CIDADE") tbm é possível fazer a segurança do metodo desta forma
-	@PostMapping(value = {"/novo", "{\\d+}"})
+	@PostMapping(value = {"/novo", "/{codigo}"})
 	@CacheEvict(value = "cidades", key = "#cidade.estado.codigo"/*O objeto pode ser navegado para se chegar na key*/, 
 	condition = "#cidade.temEstado()")
 	public ModelAndView salvar(@Valid Cidade cidade, BindingResult result, RedirectAttributes attributes){

--- a/src/main/java/com/algaworks/brewer/controller/ClientesController.java
+++ b/src/main/java/com/algaworks/brewer/controller/ClientesController.java
@@ -54,7 +54,7 @@ public class ClientesController {
 		return mv;
 	}
 	
-	@PostMapping(value = {"/novo", "{\\d+}"})
+	@PostMapping(value = {"/novo", "/{codigo}"})
 	public ModelAndView salvar(@Valid Cliente cliente, BindingResult result, RedirectAttributes attributes){
 		if(result.hasErrors()){
 			return novo(cliente);

--- a/src/main/java/com/algaworks/brewer/controller/EstilosController.java
+++ b/src/main/java/com/algaworks/brewer/controller/EstilosController.java
@@ -46,7 +46,7 @@ public class EstilosController {
 		return mv;
 	}
 	
-	@PostMapping(value = {"/novo", "{\\d+}"})
+	@PostMapping(value = {"/novo", "/{codigo}"})
 	public ModelAndView salvar(@Valid Estilo estilo, BindingResult result, Model model,
 			RedirectAttributes attributes) {
 		if (result.hasErrors()) {

--- a/src/main/java/com/algaworks/brewer/controller/UsuariosController.java
+++ b/src/main/java/com/algaworks/brewer/controller/UsuariosController.java
@@ -55,7 +55,7 @@ public class UsuariosController {
 		return mv;
 	}
 	
-	@PostMapping({"/novo", "{\\d+}"})/*As regras ficam na camada de servico, nenhuma regra e usada no controller*/
+	@PostMapping({"/novo", "/{codigo}"})/*As regras ficam na camada de servico, nenhuma regra e usada no controller*/
 	public ModelAndView salvar(@Valid Usuario usuario, BindingResult result, RedirectAttributes attributes){
 		if(result.hasErrors()){
 			return novo(usuario);

--- a/src/main/java/com/algaworks/brewer/storage/local/FotoStorageLocal.java
+++ b/src/main/java/com/algaworks/brewer/storage/local/FotoStorageLocal.java
@@ -18,7 +18,7 @@ import com.algaworks.brewer.storage.FotoStorage;
 import net.coobird.thumbnailator.Thumbnails;
 import net.coobird.thumbnailator.name.Rename;
 
-@Profile("local")
+@Profile("!prod")
 @Component
 public class FotoStorageLocal implements FotoStorage {
 
@@ -28,7 +28,7 @@ public class FotoStorageLocal implements FotoStorage {
 	private Path local;
 	
 	public FotoStorageLocal() {
-		this(getDefault().getPath(System.getenv("USERPROFILE"), ".brewerfotos"));
+		this(getDefault().getPath(System.getProperty("user.home"), ".brewerfotos"));
 	}
 	
 	public FotoStorageLocal(Path path) {


### PR DESCRIPTION
## Summary
- update MVC formatter registration to the current WebMvcConfigurer contract
- normalize edit form POST mappings to explicit /{codigo} routes
- use local photo storage by default on non-prod profiles and resolve the storage path from the user home on Linux

## Validation
- mvn test
- application bootstrap validated on Linux dev runtime
- smoke review of the diff against master

## Notes
This PR was split out from the OpenHTMLtoPDF spike work so the Spring MVC and local storage adjustments can be reviewed and merged independently.
