### PR TITLE
Coordinate Angular security upgrade to resolve frontend advisories

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,22 +10,22 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^17.3.12",
-    "@angular/common": "^17.3.12",
-    "@angular/compiler": "^17.3.12",
-    "@angular/core": "^17.3.12",
-    "@angular/forms": "^17.3.12",
-    "@angular/platform-browser": "^17.3.12",
-    "@angular/platform-browser-dynamic": "^17.3.12",
-    "@angular/router": "^17.3.12",
+    "@angular/animations": "^21.2.7",
+    "@angular/common": "^21.2.7",
+    "@angular/compiler": "^21.2.7",
+    "@angular/core": "^21.2.7",
+    "@angular/forms": "^21.2.7",
+    "@angular/platform-browser": "^21.2.7",
+    "@angular/platform-browser-dynamic": "^21.2.7",
+    "@angular/router": "^21.2.7",
     "rxjs": "~7.8.0",
-    "zone.js": "~0.14.0"
+    "zone.js": "~0.16.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.3.17",
-    "@angular/cli": "^17.3.17",
-    "@angular/compiler-cli": "^17.3.12",
+    "@angular-devkit/build-angular": "^21.2.7",
+    "@angular/cli": "^21.2.7",
+    "@angular/compiler-cli": "^21.2.7",
     "@playwright/test": "^1.40.0",
-    "typescript": "~5.3.0"
+    "typescript": "~5.9.0"
   }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -13,7 +13,7 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",


### PR DESCRIPTION
## Summary
- upgrades Angular runtime packages to the 21.2.7 line in a coordinated way
- upgrades Angular tooling (`@angular/cli`, `@angular-devkit/build-angular`, `@angular/compiler-cli`) to the same major line
- updates `zone.js` to 0.16 and TypeScript to 5.9
- switches TypeScript `moduleResolution` to `bundler` for Angular 21 compatibility

## Why
We currently have multiple high-severity Dependabot alerts affecting Angular packages. Instead of unsafe isolated major bumps, this PR applies a single compatible upgrade track so security and build compatibility are handled together.

## Validation
- `cd frontend && npm install`
- `cd frontend && npm run build`

## Follow-up
After this PR is merged, re-run Dependabot alert review and close outdated isolated frontend dependency PRs that are superseded by this coordinated migration.
