### PR TITLE
feat: adicionar suporte a Docker com MariaDB (docker compose)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Build output
+target/
+
+# Frontend dependencies e build
+frontend/node_modules/
+frontend/dist/
+
+# E2E
+e2e/node_modules/
+
+# Git
+.git/
+.gitignore
+
+# IDE
+.idea/
+*.iml
+.vscode/
+
+# Logs
+*.log
+
+# Variáveis de ambiente locais (não enviar segredos para a imagem)
+.env
+.env.*
+!.env.example

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Copie este arquivo para .env e preencha os valores antes de executar docker compose up
+
+# ─── Banco de Dados ────────────────────────────────────────────────────────────
+DB_ROOT_PASSWORD=root
+DB_NAME=brewer
+DB_USER=brewer
+DB_PASSWORD=brewer
+
+# ─── Email (opcional – deixe em branco para desabilitar) ──────────────────────
+MAIL_HOST=smtp.sendgrid.net
+MAIL_PORT=587
+MAIL_USERNAME=
+MAIL_PASSWORD=
+
+# ─── AWS S3 (opcional – deixe em branco para desabilitar upload em nuvem) ─────
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_S3_BUCKET=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# ─── Stage 1: Build ───────────────────────────────────────────────────────────
+FROM maven:3.9-eclipse-temurin-17 AS build
+
+WORKDIR /app
+
+# Copia somente o pom.xml primeiro para aproveitar o cache de dependências
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+# Copia o código-fonte e empacota
+COPY src ./src
+RUN mvn package -DskipTests -B
+
+# ─── Stage 2: Runtime ─────────────────────────────────────────────────────────
+FROM eclipse-temurin:17-jre-alpine
+
+WORKDIR /app
+
+# Cria usuário não-root para executar a aplicação
+RUN addgroup -S brewer && adduser -S brewer -G brewer
+
+COPY --from=build /app/target/brewer.jar app.jar
+
+RUN chown brewer:brewer app.jar
+
+USER brewer
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+services:
+
+  db:
+    image: mariadb:11.3
+    container_name: brewer-db
+    restart: unless-stopped
+    environment:
+      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-root}
+      MARIADB_DATABASE: ${DB_NAME:-brewer}
+      MARIADB_USER: ${DB_USER:-brewer}
+      MARIADB_PASSWORD: ${DB_PASSWORD:-brewer}
+    volumes:
+      - mariadb_data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${DB_ROOT_PASSWORD:-root}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  app:
+    build: .
+    container_name: brewer-app
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: docker,prod
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_NAME: ${DB_NAME:-brewer}
+      DB_USER: ${DB_USER:-brewer}
+      DB_PASSWORD: ${DB_PASSWORD:-brewer}
+      # Configurações opcionais de e-mail
+      MAIL_HOST: ${MAIL_HOST:-smtp.sendgrid.net}
+      MAIL_PORT: ${MAIL_PORT:-587}
+      MAIL_USERNAME: ${MAIL_USERNAME:-}
+      MAIL_PASSWORD: ${MAIL_PASSWORD:-}
+      # Configurações opcionais de AWS S3
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_S3_BUCKET: ${AWS_S3_BUCKET:-}
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  mariadb_data:

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,15 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 <version>${mariadb-connector-java.version}</version>
 <scope>compile</scope>
 </dependency>
+<!-- Flyway runtime: executa migrações automaticamente ao iniciar a aplicação -->
+<dependency>
+<groupId>org.flywaydb</groupId>
+<artifactId>flyway-core</artifactId>
+</dependency>
+<dependency>
+<groupId>org.flywaydb</groupId>
+<artifactId>flyway-mysql</artifactId>
+</dependency>
 </dependencies>
 </profile>
 </profiles>

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,0 +1,37 @@
+# ─── Database (MariaDB) ───────────────────────────────────────────────────────
+spring.datasource.url=jdbc:mariadb://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:brewer}
+spring.datasource.driverClassName=org.mariadb.jdbc.Driver
+spring.datasource.username=${DB_USER:brewer}
+spring.datasource.password=${DB_PASSWORD:brewer}
+
+# ─── JPA / Hibernate ──────────────────────────────────────────────────────────
+spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
+
+# ─── Flyway (cria / migra esquema automaticamente) ───────────────────────────
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true
+
+# ─── H2 desabilitado em Docker ────────────────────────────────────────────────
+spring.h2.console.enabled=false
+
+# ─── Thymeleaf ────────────────────────────────────────────────────────────────
+spring.thymeleaf.cache=true
+
+# ─── Mail ─────────────────────────────────────────────────────────────────────
+mail.host=${MAIL_HOST:smtp.sendgrid.net}
+mail.port=${MAIL_PORT:587}
+mail.username=${MAIL_USERNAME:}
+mail.password=${MAIL_PASSWORD:}
+
+# ─── AWS S3 ───────────────────────────────────────────────────────────────────
+aws.access.key.id=${AWS_ACCESS_KEY_ID:}
+aws.secret.access.key=${AWS_SECRET_ACCESS_KEY:}
+aws.s3.bucket=${AWS_S3_BUCKET:}
+
+# ─── Logging ──────────────────────────────────────────────────────────────────
+logging.level.root=INFO
+logging.level.com.algaworks.brewer=INFO


### PR DESCRIPTION
## Objetivo

Permitir executar toda a stack (app Java + MariaDB) com um único `docker compose up --build`.

## Arquivos adicionados

| Arquivo | Função |
|---|---|
| `Dockerfile` | Multi-stage: `maven:3.9-temurin-17` para build, `temurin-17-jre-alpine` para runtime; processo Java roda como usuário não-root `brewer` |
| `docker-compose.yml` | Orquestra `app` + `db` (MariaDB 11.3); health check no banco antes de iniciar o app; variáveis de ambiente via `.env` |
| `application-docker.properties` | Perfil `docker`: datasource MariaDB, Flyway habilitado com `baseline-on-migrate`, H2 desabilitado, Thymeleaf com cache |
| `.dockerignore` | Exclui `target/`, `node_modules/`, `.git/`, `.env.*` do contexto de build |
| `.env.example` | Template de variáveis para desenvolvedores (DB, mail, AWS S3) |

## Correções de validação aplicadas

Durante a revisão da configuração existente foram identificados e corrigidos três problemas:

1. **`SPRING_PROFILES_ACTIVE`** estava como `docker` apenas → `FotoStorageLocal` (`@Profile("local")`) e `FotoStorageS3` (`@Profile("prod")`) **nenhum** seria instanciado; corrigido para `docker,prod`
2. **Flyway ausente em runtime**: o `flyway-maven-plugin` só executa via Maven, nunca dentro do JAR; adicionado `flyway-core` + `flyway-mysql` como dependências no perfil Maven `prod`
3. **`spring.flyway.enabled=true`** com `baseline-on-migrate=true` adicionado ao `application-docker.properties` para garantir criação do schema no primeiro start

## Como usar

```bash
cp .env.example .env        # preencher credenciais se necessário
docker compose up --build   # primeiro start (build + migrações Flyway)
docker compose up           # starts subsequentes
```

A aplicação estará disponível em http://localhost:8080