### PR TITLE
feat: suporte Docker para deploy no Raspberry Pi (ARM64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ Network Trash Folder
 Temporary Items
 .apdisk
 /target/
+
+# Variáveis de ambiente locais (contém credenciais)
+.env
+.env.*
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ WORKDIR /app
 
 # Copia somente o pom.xml primeiro para aproveitar o cache de dependências
 COPY pom.xml .
-RUN mvn dependency:go-offline -B
+# || true: ehcache:jakarta puxa deps transitivas de repos HTTP antigos (java.net),
+# bloqueados pelo Maven 3.8+. O stage de package baixa o restante.
+RUN mvn dependency:go-offline -B || true
 
 # Copia o código-fonte e empacota
 COPY src ./src
@@ -16,15 +18,22 @@ FROM eclipse-temurin:17-jre
 
 WORKDIR /app
 
-# Cria usuário não-root para executar a aplicação
-RUN groupadd -r brewer && useradd -r -g brewer brewer
+# Instala wget para o HEALTHCHECK e cria usuário não-root
+RUN apt-get update && apt-get install -y --no-install-recommends wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && addgroup --system brewer && adduser --system --ingroup brewer brewer
 
 COPY --from=build /app/target/brewer.jar app.jar
 
-RUN chown brewer:brewer app.jar
+RUN chown brewer:brewer app.jar && \
+    chmod 644 app.jar
 
 USER brewer
 
 EXPOSE 8080
+
+# Usa /login pois Actuator não está configurado
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/login || exit 1
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@ COPY src ./src
 RUN mvn package -DskipTests -B
 
 # ─── Stage 2: Runtime ─────────────────────────────────────────────────────────
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
 
 WORKDIR /app
 
 # Cria usuário não-root para executar a aplicação
-RUN addgroup -S brewer && adduser -S brewer -G brewer
+RUN groupadd -r brewer && useradd -r -g brewer brewer
 
 COPY --from=build /app/target/brewer.jar app.jar
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     container_name: brewer-app
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "8081:8080"
     environment:
       SPRING_PROFILES_ACTIVE: docker,prod
       DB_HOST: db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,11 @@ services:
     ports:
       - "3306:3306"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${DB_ROOT_PASSWORD:-root}"]
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 10s
       timeout: 5s
       retries: 10
+      start_period: 30s
 
   app:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,12 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/login"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
 
 volumes:
   mariadb_data:

--- a/src/main/java/com/algaworks/brewer/controller/UsuariosController.java
+++ b/src/main/java/com/algaworks/brewer/controller/UsuariosController.java
@@ -79,7 +79,7 @@ public class UsuariosController {
 	@GetMapping
 	public ModelAndView pesquisar(UsuarioFilter usuarioFilter
 			, @PageableDefault(size=3) Pageable pageable, HttpServletRequest httpServletRequest){
-		ModelAndView mv = new ModelAndView("/usuario/PesquisaUsuarios");
+		ModelAndView mv = new ModelAndView("usuario/PesquisaUsuarios");
 		mv.addObject("usuarios", usuarios.filtrar(usuarioFilter, pageable));
 		mv.addObject("grupos", grupos.findAll());
 		

--- a/src/main/java/com/algaworks/brewer/controller/VendasController.java
+++ b/src/main/java/com/algaworks/brewer/controller/VendasController.java
@@ -151,7 +151,7 @@ public class VendasController {
 	@GetMapping
 	public ModelAndView pesquisar(VendaFilter vendaFilter,
 			@PageableDefault(size = 10) Pageable pageable, HttpServletRequest httpServletRequest) {
-		ModelAndView mv = new ModelAndView("/venda/PesquisaVendas");
+		ModelAndView mv = new ModelAndView("venda/PesquisaVendas");
 		mv.addObject("todosStatus", StatusVenda.values());
 		mv.addObject("tiposPessoa", TipoPessoa.values());
 		
@@ -181,7 +181,7 @@ public class VendasController {
 		try {
 			cadastroVendaService.cancelar(venda);
 		} catch (AccessDeniedException e) {
-			return new ModelAndView("/403");
+			return new ModelAndView("403");
 		}
 		
 		attributes.addFlashAttribute("mensagem", "Venda cancelada com sucesso");

--- a/src/main/java/com/algaworks/brewer/model/Cerveja.java
+++ b/src/main/java/com/algaworks/brewer/model/Cerveja.java
@@ -70,10 +70,12 @@ public class Cerveja implements Serializable {
 	
 	@NotNull
 	@Enumerated(EnumType.STRING)
+	@Column(columnDefinition = "varchar(50)")
 	private Origem origem;
 	
 	@NotNull
 	@Enumerated(EnumType.STRING)
+	@Column(columnDefinition = "varchar(50)")
 	private Sabor sabor;
 	
 	@ManyToOne

--- a/src/main/java/com/algaworks/brewer/model/Cliente.java
+++ b/src/main/java/com/algaworks/brewer/model/Cliente.java
@@ -48,7 +48,7 @@ public class Cliente implements Serializable{
 
 	@NotNull
 	@Enumerated(EnumType.STRING)
-	@Column(name = "tipo_pessoa")
+	@Column(name = "tipo_pessoa", columnDefinition = "varchar(15)")
 	private TipoPessoa tipoPessoa;
 
 	@NotBlank

--- a/src/main/java/com/algaworks/brewer/model/Venda.java
+++ b/src/main/java/com/algaworks/brewer/model/Venda.java
@@ -61,6 +61,7 @@ public class Venda {
 	private Usuario usuario;
 	
 	@Enumerated(EnumType.STRING)
+	@Column(columnDefinition = "varchar(30)")
 	private StatusVenda status = StatusVenda.ORCAMENTO;
 
 	@OneToMany(mappedBy = "venda", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/resources/db/migration/V15__popular_dados_demo.sql
+++ b/src/main/resources/db/migration/V15__popular_dados_demo.sql
@@ -1,0 +1,236 @@
+-- =============================================================
+-- Vendedores (grupo 2 = Vendedor)
+-- Senha: mesma do admin
+-- =============================================================
+INSERT INTO usuario (nome, email, senha, ativo) VALUES
+  ('Carlos Oliveira', 'carlos@brewer.com', '$2a$10$x3dW.vGNa.OsxIBZ7qi36uScizK1I1UspCXjasBlnZ31k5yiw.KCa', 1),
+  ('Ana Santos',      'ana@brewer.com',    '$2a$10$x3dW.vGNa.OsxIBZ7qi36uScizK1I1UspCXjasBlnZ31k5yiw.KCa', 1);
+
+INSERT INTO usuario_grupo (codigo_usuario, codigo_grupo) VALUES
+  ((SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'), 2),
+  ((SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'),    2);
+
+-- =============================================================
+-- Clientes (2 pessoa física, 1 pessoa jurídica)
+-- =============================================================
+INSERT INTO cliente (nome, tipo_pessoa, cpf_cnpj, telefone, email) VALUES
+  ('João Pereira',  'FISICA',    '111.444.777-35',      '(11) 91234-5678', 'joao.pereira@email.com'),
+  ('Maria Lima',    'FISICA',    '987.654.321-00',      '(21) 98765-4321', 'maria.lima@email.com'),
+  ('Bares e Cia',   'JURIDICA',  '24.527.248/0001-08',  '(31) 3456-7890',  'contato@barecia.com');
+
+-- =============================================================
+-- Estilos extras (IDs 5, 6, 7 — IDs 1-4 criados em V01)
+-- =============================================================
+INSERT INTO estilo VALUES (0, 'IPA');
+INSERT INTO estilo VALUES (0, 'Stout');
+INSERT INTO estilo VALUES (0, 'Weizen');
+
+-- =============================================================
+-- Cervejas (10)
+-- =============================================================
+INSERT INTO cerveja (sku, nome, descricao, valor, teor_alcoolico, comissao, sabor, origem, codigo_estilo, quantidade_estoque) VALUES
+  ('SKU001', 'Amber Dream',        'Lager âmbar encorpada com aroma de caramelo.',              18.90, 4.8, 3.00, 'ADOCICADA', 'NACIONAL',      1, 100),
+  ('SKU002', 'Dark Night',         'Lager escura com notas de chocolate amargo e café.',         22.50, 5.2, 4.00, 'AMARGA',    'NACIONAL',      2,  80),
+  ('SKU003', 'Pale Rider',         'Pale lager leve e refrescante, ideal para dias quentes.',    16.00, 4.0, 2.50, 'SUAVE',     'NACIONAL',      3, 120),
+  ('SKU004', 'Prague Gold',        'Pilsner com lúpulo aromático e baixo amargor.',              19.90, 4.4, 3.50, 'SUAVE',     'INTERNACIONAL', 4,  90),
+  ('SKU005', 'Hops Valley IPA',    'IPA com explosão de lúpulo cítrico e tropical.',             28.00, 6.8, 5.00, 'AMARGA',    'INTERNACIONAL', 5,  60),
+  ('SKU006', 'Midnight Stout',     'Stout robusto com sabor de toffee e baunilha.',              32.00, 7.5, 5.50, 'FORTE',     'INTERNACIONAL', 6,  50),
+  ('SKU007', 'Bavarian Wheat',     'Weizen bávara tradicional com notas de banana e cravo.',     24.00, 5.0, 4.00, 'FRUTADA',   'INTERNACIONAL', 7,  70),
+  ('SKU008', 'Sertão Lager',       'Pilsner artesanal brasileira com milho nativo.',             15.50, 4.2, 2.00, 'SUAVE',     'NACIONAL',      3, 150),
+  ('SKU009', 'Caramel Ale',        'Pale lager com malte caramelo e finalização doce.',          20.00, 4.6, 3.00, 'ADOCICADA', 'NACIONAL',      3, 110),
+  ('SKU010', 'Tropical Storm IPA', 'IPA com maracujá, manga e abacaxi.',                         30.00, 7.0, 5.00, 'FRUTADA',   'NACIONAL',      5,  40);
+
+-- =============================================================
+-- Vendas — 4 por cliente × 3 clientes × 2 vendedores = 24
+-- Padrão por grupo de 4: EMITIDA, EMITIDA, ORCAMENTO, CANCELADA
+-- =============================================================
+
+-- ---- Carlos × João ------------------------------------------
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-01-10 09:00:00', 85.80, 'EMITIDA',
+   (SELECT codigo FROM cliente WHERE email = 'joao.pereira@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (2, 18.90, (SELECT codigo FROM cerveja WHERE sku = 'SKU001'), LAST_INSERT_ID()),
+  (3, 16.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU003'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-01-18 14:00:00', 50.90, 'EMITIDA',
+   (SELECT codigo FROM cliente WHERE email = 'joao.pereira@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (1, 19.90, (SELECT codigo FROM cerveja WHERE sku = 'SKU004'), LAST_INSERT_ID()),
+  (2, 15.50, (SELECT codigo FROM cerveja WHERE sku = 'SKU008'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-02-05 10:30:00', 90.00, 'ORCAMENTO',
+   (SELECT codigo FROM cliente WHERE email = 'joao.pereira@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (4, 22.50, (SELECT codigo FROM cerveja WHERE sku = 'SKU002'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-02-20 16:00:00', 88.00, 'CANCELADA',
+   (SELECT codigo FROM cliente WHERE email = 'joao.pereira@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (1, 32.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU006'), LAST_INSERT_ID()),
+  (2, 28.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU005'), LAST_INSERT_ID());
+
+-- ---- Carlos × Maria -----------------------------------------
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-01-12 11:00:00', 112.00, 'EMITIDA',
+   (SELECT codigo FROM cliente WHERE email = 'maria.lima@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (3, 24.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU007'), LAST_INSERT_ID()),
+  (2, 20.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU009'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-01-25 09:30:00', 78.00, 'EMITIDA',
+   (SELECT codigo FROM cliente WHERE email = 'maria.lima@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (1, 30.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU010'), LAST_INSERT_ID()),
+  (3, 16.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU003'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-02-08 15:00:00', 37.80, 'ORCAMENTO',
+   (SELECT codigo FROM cliente WHERE email = 'maria.lima@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (2, 18.90, (SELECT codigo FROM cerveja WHERE sku = 'SKU001'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-03-01 10:00:00', 77.50, 'CANCELADA',
+   (SELECT codigo FROM cliente WHERE email = 'maria.lima@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (5, 15.50, (SELECT codigo FROM cerveja WHERE sku = 'SKU008'), LAST_INSERT_ID());
+
+-- ---- Carlos × Bares e Cia -----------------------------------
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-01-15 08:00:00', 237.50, 'EMITIDA',
+   (SELECT codigo FROM cliente WHERE email = 'contato@barecia.com'),
+   (SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (10, 16.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU003'), LAST_INSERT_ID()),
+  ( 5, 15.50, (SELECT codigo FROM cerveja WHERE sku = 'SKU008'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-01-28 13:00:00', 147.10, 'EMITIDA',
+   (SELECT codigo FROM cliente WHERE email = 'contato@barecia.com'),
+   (SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (3, 22.50, (SELECT codigo FROM cerveja WHERE sku = 'SKU002'), LAST_INSERT_ID()),
+  (4, 19.90, (SELECT codigo FROM cerveja WHERE sku = 'SKU004'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-02-14 11:00:00', 113.40, 'ORCAMENTO',
+   (SELECT codigo FROM cliente WHERE email = 'contato@barecia.com'),
+   (SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (6, 18.90, (SELECT codigo FROM cerveja WHERE sku = 'SKU001'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-03-05 09:00:00', 148.00, 'CANCELADA',
+   (SELECT codigo FROM cliente WHERE email = 'contato@barecia.com'),
+   (SELECT codigo FROM usuario WHERE email = 'carlos@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (2, 32.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU006'), LAST_INSERT_ID()),
+  (3, 28.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU005'), LAST_INSERT_ID());
+
+-- ---- Ana × João ---------------------------------------------
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-01-11 10:00:00', 120.00, 'EMITIDA',
+   (SELECT codigo FROM cliente WHERE email = 'joao.pereira@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (3, 20.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU009'), LAST_INSERT_ID()),
+  (2, 30.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU010'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-01-22 14:30:00', 96.00, 'EMITIDA',
+   (SELECT codigo FROM cliente WHERE email = 'joao.pereira@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (4, 24.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU007'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-02-10 09:00:00', 120.00, 'ORCAMENTO',
+   (SELECT codigo FROM cliente WHERE email = 'joao.pereira@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (2, 32.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU006'), LAST_INSERT_ID()),
+  (2, 28.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU005'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-02-25 16:00:00', 99.50, 'CANCELADA',
+   (SELECT codigo FROM cliente WHERE email = 'joao.pereira@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (5, 19.90, (SELECT codigo FROM cerveja WHERE sku = 'SKU004'), LAST_INSERT_ID());
+
+-- ---- Ana × Maria --------------------------------------------
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-01-14 11:00:00', 101.70, 'EMITIDA',
+   (SELECT codigo FROM cliente WHERE email = 'maria.lima@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (2, 22.50, (SELECT codigo FROM cerveja WHERE sku = 'SKU002'), LAST_INSERT_ID()),
+  (3, 18.90, (SELECT codigo FROM cerveja WHERE sku = 'SKU001'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-01-30 10:00:00', 94.00, 'EMITIDA',
+   (SELECT codigo FROM cliente WHERE email = 'maria.lima@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (4, 15.50, (SELECT codigo FROM cerveja WHERE sku = 'SKU008'), LAST_INSERT_ID()),
+  (2, 16.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU003'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-02-12 15:30:00', 60.00, 'ORCAMENTO',
+   (SELECT codigo FROM cliente WHERE email = 'maria.lima@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (3, 20.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU009'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-03-03 09:30:00', 80.00, 'CANCELADA',
+   (SELECT codigo FROM cliente WHERE email = 'maria.lima@email.com'),
+   (SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (1, 32.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU006'), LAST_INSERT_ID()),
+  (2, 24.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU007'), LAST_INSERT_ID());
+
+-- ---- Ana × Bares e Cia --------------------------------------
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-01-16 08:30:00', 221.00, 'EMITIDA',
+   (SELECT codigo FROM cliente WHERE email = 'contato@barecia.com'),
+   (SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (8, 16.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU003'), LAST_INSERT_ID()),
+  (6, 15.50, (SELECT codigo FROM cerveja WHERE sku = 'SKU008'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-02-01 13:00:00', 156.20, 'EMITIDA',
+   (SELECT codigo FROM cliente WHERE email = 'contato@barecia.com'),
+   (SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (5, 19.90, (SELECT codigo FROM cerveja WHERE sku = 'SKU004'), LAST_INSERT_ID()),
+  (3, 18.90, (SELECT codigo FROM cerveja WHERE sku = 'SKU001'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-02-18 10:00:00', 120.00, 'ORCAMENTO',
+   (SELECT codigo FROM cliente WHERE email = 'contato@barecia.com'),
+   (SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (4, 30.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU010'), LAST_INSERT_ID());
+
+INSERT INTO venda (data_criacao, valor_total, status, codigo_cliente, codigo_usuario) VALUES
+  ('2026-03-10 11:00:00', 129.00, 'CANCELADA',
+   (SELECT codigo FROM cliente WHERE email = 'contato@barecia.com'),
+   (SELECT codigo FROM usuario WHERE email = 'ana@brewer.com'));
+INSERT INTO item_venda (quantidade, valor_unitario, codigo_cerveja, codigo_venda) VALUES
+  (3, 28.00, (SELECT codigo FROM cerveja WHERE sku = 'SKU005'), LAST_INSERT_ID()),
+  (2, 22.50, (SELECT codigo FROM cerveja WHERE sku = 'SKU002'), LAST_INSERT_ID());

--- a/src/main/resources/templates/cliente/PesquisaCliente.html
+++ b/src/main/resources/templates/cliente/PesquisaCliente.html
@@ -73,7 +73,7 @@
 							<td class="text-right" th:text="${cliente.cpfOuCnpj}">111.111.111-11</td>
 							<td class="text-right" th:text="${cliente.telefone}">(11) 99999-9999</td>
 							<td class="text-right"
-								th:text="${cliente.endereco.nomeCidadeSiglaEstado}">
+								th:text="${cliente.endereco?.nomeCidadeSiglaEstado}">
 							</td>
 								
 							<td class="text-center" sec:authorize="hasRole('ROLE_CADASTRAR_CIDADE')">

--- a/src/main/resources/templates/relatorio/RelatorioVendasEmitidas.html
+++ b/src/main/resources/templates/relatorio/RelatorioVendasEmitidas.html
@@ -27,10 +27,12 @@
 					<label for="dataInicio" th:text="#{vendasEmitidas.dataCriacao}">Data de criação</label>
 					<div class="form-inline">
 						<input type="text" class="form-control  aw-form-control-inline-sm  js-date" 
-							id="dataInicio" th:field="*{dataInicio}" autocomplete="off" required/>
+							id="dataInicio" th:field="*{dataInicio}" autocomplete="off" bw-required
+							brewer:classforerror="dataInicio"/>
 						<label for="a" class="aw-form-label-between">a</label>
 						<input type="text" class="form-control  aw-form-control-inline-sm  js-date" 
-							id="dataFim" th:field="*{dataFim}" autocomplete="off" required/>
+							id="dataFim" th:field="*{dataFim}" autocomplete="off" bw-required
+							brewer:classforerror="dataFim"/>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Resumo

Adiciona suporte completo ao Docker para deploy da aplicação Brewer em um servidor Raspberry Pi (ARM64), incluindo correções de compatibilidade com Hibernate 6 + MariaDB e dados de demonstração.

## Alterações

### Docker
- `Dockerfile`: migra imagem de runtime de `eclipse-temurin:17-jre-alpine` (sem suporte ARM64) para `eclipse-temurin:17-jre` (Debian, suporta ARM64); instala `wget` para healthcheck; usa `addgroup`/`adduser` no formato Debian; adiciona `chmod 644` no jar; adiciona `HEALTHCHECK`
- `docker-compose.yml`: corrige healthcheck do MariaDB usando `healthcheck.sh` nativo (evita falha de expansão de variável em `CMD` array); adiciona healthcheck no serviço `app`; porta do host alterada para `8081` (porta 8080 ocupada pelo Keycloak no servidor)
- `.gitignore`: adiciona `.env` e `.env.*` para não expor credenciais

### Correções de compatibilidade (Hibernate 6 + MariaDB)
- `Cerveja`, `Cliente`, `Venda`: adiciona `columnDefinition="varchar(N)"` nas colunas `@Enumerated(EnumType.STRING)` — o Hibernate 6 com dialeto MariaDB passou a mapear enums para o tipo `ENUM` nativo, mas as migrations usam `VARCHAR`

### Correções de template
- `UsuariosController`, `VendasController`: remove barra inicial nos nomes de view (`/usuario/PesquisaUsuarios` → `usuario/PesquisaUsuarios`) para evitar duplo slash com o prefixo Thymeleaf
- `PesquisaCliente.html`: usa operador safe-navigation (`?.`) em `cliente.endereco` para evitar `NullPointerException` em clientes sem endereço

### Dados de demonstração
- `V15__popular_dados_demo.sql`: insere 2 vendedores, 3 clientes, 10 cervejas (3 estilos extras), 24 vendas (4 por combinação vendedor×cliente) com status variados (EMITIDA, ORCAMENTO, CANCELADA)
