### PR TITLE
docs: atualiza README e SECURITY.md com estado atual do projeto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,135 @@
-# Brewer - Sistema de Gerenciamento de Cervejas
+# Brewer — Sistema de Gerenciamento de Cervejaria
 
-Sistema de gerenciamento de cervejaria desenvolvido com Spring Boot 3.x e Angular.
+Sistema web para gestão de cervejaria: cadastro de cervejas, clientes, vendas, relatórios e controle de usuários. Desenvolvido com Spring Boot 3 (MVC + REST) e Angular, com suporte a deploy via Docker.
 
 ## Tecnologias
 
 ### Backend
-- **Java 17** - Linguagem de programação
-- **Spring Boot 3.2.5** - Framework principal
-- **Spring Security 6** - Autenticação e autorização
-- **Spring Data JPA** - Persistência de dados
-- **Hibernate 6** - ORM
-- **Thymeleaf** - Template engine para views tradicionais
-- **H2 Database** - Banco de dados em memória para desenvolvimento
+| Tecnologia | Versão | Função |
+|---|---|---|
+| Java | 17 | Linguagem de programação |
+| Spring Boot | 3.2.5 | Framework principal |
+| Spring Security 6 | — | Autenticação e autorização (form login) |
+| Spring Data JPA + Hibernate 6 | — | ORM e persistência |
+| Thymeleaf | — | Templates server-side (views MVC) |
+| Flyway | 10.10.0 | Migrations de banco de dados |
+| MariaDB | 11.3 (prod) / H2 (dev) | Banco de dados |
+| EhCache 3 | — | Cache de segundo nível |
+| JasperReports / OpenHTMLtoPDF | — | Geração de relatórios PDF |
+| Spring Mail | — | Envio de e-mails transacionais |
 
-### Frontend
-- **Angular 21.2.7** - Framework SPA
-- **TypeScript 5.9** - Linguagem de programação tipada
-- **RxJS** - Programação reativa
+### Frontend (SPA)
+| Tecnologia | Versão | Função |
+|---|---|---|
+| Angular | 21.2.7 | Framework SPA |
+| TypeScript | 5.9 | Linguagem tipada |
+| RxJS | — | Programação reativa |
+
+### Infraestrutura
+| Tecnologia | Versão | Função |
+|---|---|---|
+| Docker | — | Containerização |
+| Docker Compose | — | Orquestração local |
+| eclipse-temurin:17-jre | — | Imagem base de runtime (suporta ARM64) |
 
 ### Testes
-- **JUnit 5** - Testes unitários
-- **Playwright** - Testes E2E
+| Ferramenta | Escopo |
+|---|---|
+| JUnit 5 | Unitários (backend) |
+| Playwright | E2E (web + API) |
 
 ## Estrutura do Projeto
 
 ```
 brewer/
-├── src/main/java/           # Código-fonte Java
-│   └── com/algaworks/brewer/
-│       ├── api/             # Controladores REST API
-│       ├── config/          # Configurações Spring
-│       ├── controller/      # Controladores MVC
-│       ├── model/           # Entidades JPA
-│       ├── repository/      # Repositórios Spring Data
-│       └── Service/         # Camada de serviços
-├── src/main/resources/      # Recursos (templates, configs)
-├── frontend/                # Aplicação Angular
-│   └── src/
-│       └── app/
-│           ├── components/  # Componentes Angular
-│           ├── models/      # Modelos TypeScript
-│           └── services/    # Serviços HTTP
-└── e2e/                     # Testes E2E Playwright
+├── Dockerfile                  # Imagem Docker multi-stage
+├── docker-compose.yml          # Orquestração app + MariaDB
+├── .env.example                # Template de variáveis de ambiente
+├── Procfile                    # Deploy Heroku/Render
+├── pom.xml                     # Build Maven
+├── src/
+│   └── main/
+│       ├── java/com/algaworks/brewer/
+│       │   ├── api/            # Controllers REST
+│       │   ├── config/         # Configurações Spring (Security, Cache, Mail…)
+│       │   ├── controller/     # Controllers MVC (Thymeleaf)
+│       │   ├── model/          # Entidades JPA
+│       │   ├── repository/     # Repositórios Spring Data
+│       │   ├── service/        # Camada de serviços
+│       │   ├── dto/            # DTOs de API
+│       │   └── storage/        # Abstração de armazenamento (S3 / local)
+│       └── resources/
+│           ├── application.properties
+│           ├── db/migration/   # Scripts Flyway (V01…V15)
+│           ├── templates/      # Views Thymeleaf
+│           └── relatorios/     # Templates JasperReports (.jasper)
+├── frontend/                   # Aplicação Angular
+│   └── src/app/
+│       ├── components/         # Componentes
+│       ├── models/             # Modelos TypeScript
+│       └── services/           # Serviços HTTP
+└── e2e/                        # Testes E2E Playwright
     └── tests/
 ```
 
 ## API REST
 
-O sistema expõe as seguintes APIs RESTful:
-
-| Recurso | Endpoint | Métodos |
-|---------|----------|---------|
+| Recurso | Endpoint base | Métodos disponíveis |
+|---|---|---|
 | Cervejas | `/api/cervejas` | GET, POST, PUT, DELETE |
 | Estilos | `/api/estilos` | GET, POST, PUT, DELETE |
 | Clientes | `/api/clientes` | GET, POST, PUT, DELETE |
 | Cidades | `/api/cidades` | GET, POST, PUT |
 | Estados | `/api/estados` | GET |
 | Vendas | `/api/vendas` | GET |
+| Estatísticas de vendas | `/api/vendas/stats/por-origem` | GET |
 | Usuários | `/api/usuarios` | GET, POST, PUT |
 
-## Executando o Projeto
+## Executando com Docker (recomendado)
+
+> Pré-requisito: Docker e Docker Compose instalados. Compatível com AMD64 e **ARM64 (Raspberry Pi)**.
+
+```bash
+# 1. Copie o arquivo de variáveis de ambiente
+cp .env.example .env
+# Edite .env se necessário (senhas, e-mail, S3)
+
+# 2. Build e inicialização
+docker compose up --build
+
+# 3. Acesse a aplicação
+# http://localhost:8081
+```
+
+O Flyway aplica automaticamente as migrations V01–V15 na primeira inicialização, incluindo dados de demonstração (2 vendedores, 3 clientes, 10 cervejas e 24 vendas).
+
+**Credenciais padrão:** `admin@brewer.com` / `admin123`
+
+### Serviços Docker
+
+| Serviço | Container | Porta host | Porta interna |
+|---|---|---|---|
+| Aplicação | `brewer-app` | `8081` | `8080` |
+| MariaDB | `brewer-db` | `3306` | `3306` |
+
+## Executando Localmente (sem Docker)
+
+### Pré-requisitos
+- Java 17+
+- Maven 3.9+
+- (opcional) MariaDB 11+ para usar perfil `prod`
 
 ### Backend
 
 ```bash
-# Compilar
-mvn clean compile
-
-# Executar testes
-mvn test
-
-# Iniciar aplicação
+# Perfil de desenvolvimento (H2 em memória — sem banco externo)
 mvn spring-boot:run
+
+# Perfil de produção (MariaDB externo)
+mvn spring-boot:run -Dspring-boot.run.profiles=prod
 ```
 
-A aplicação estará disponível em `http://localhost:8080`
+Disponível em `http://localhost:8080`.
 
 ### Frontend
 
@@ -84,7 +139,7 @@ npm install
 npm start
 ```
 
-A aplicação Angular estará disponível em `http://localhost:4200`
+Disponível em `http://localhost:4200`.
 
 ### Testes E2E
 
@@ -97,27 +152,65 @@ npm test
 
 ## Configuração
 
-### application.properties
+### Perfis de Aplicação
 
-O arquivo `src/main/resources/application.properties` contém as configurações da aplicação:
+| Perfil | Banco | Descrição |
+|---|---|---|
+| `default` | H2 (memória) | Desenvolvimento local, sem configuração externa |
+| `prod` | MariaDB | Produção via variáveis de ambiente ou `application-prod.properties` |
+| `docker` | MariaDB (container) | Composição com `docker-compose.yml` |
 
-- **Banco de dados**: H2 em memória (desenvolvimento)
-- **JPA**: Auto-criação de schema
-- **Thymeleaf**: Templates em `classpath:/templates/`
+### Variáveis de Ambiente (Docker / prod)
 
-### Variáveis de Ambiente
+| Variável | Padrão | Descrição |
+|---|---|---|
+| `DB_HOST` | `db` | Host do MariaDB |
+| `DB_PORT` | `3306` | Porta do MariaDB |
+| `DB_NAME` | `brewer` | Nome do banco |
+| `DB_USER` | `brewer` | Usuário do banco |
+| `DB_PASSWORD` | `brewer` | Senha do banco |
+| `DB_ROOT_PASSWORD` | `root` | Senha root do MariaDB |
+| `MAIL_HOST` | `smtp.sendgrid.net` | Servidor SMTP |
+| `MAIL_PORT` | `587` | Porta SMTP |
+| `MAIL_USERNAME` | — | Usuário SMTP |
+| `MAIL_PASSWORD` | — | Senha SMTP |
+| `AWS_ACCESS_KEY_ID` | — | AWS Access Key (upload S3) |
+| `AWS_SECRET_ACCESS_KEY` | — | AWS Secret Key |
+| `AWS_S3_BUCKET` | — | Bucket S3 para fotos de cervejas |
 
-| Variável | Descrição |
-|----------|-----------|
-| `aws.access.key.id` | AWS Access Key para S3 |
-| `aws.secret.access.key` | AWS Secret Key para S3 |
-| `mail.username` | Usuário do servidor de email |
-| `mail.password` | Senha do servidor de email |
+### Controle de Acesso
 
-## Migração de Versões
+O sistema usa grupos e permissões granulares:
 
-Este projeto foi migrado de:
-- Java 8 → Java 17
+| Grupo | Descrição |
+|---|---|
+| `Administrador` | Acesso total |
+| `Vendedor` | Acesso a vendas e consultas |
+
+| Role | Descrição |
+|---|---|
+| `ROLE_CADASTRAR_CIDADE` | Cadastrar e editar cidades |
+| `ROLE_CADASTRAR_USUARIO` | Cadastrar e editar usuários |
+| `ROLE_CANCELAR_VENDA` | Cancelar vendas emitidas |
+
+## Migrações de Banco (Flyway)
+
+| Migration | Descrição |
+|---|---|
+| V01 | Tabelas `estilo` e `cerveja` + estilos iniciais |
+| V02–V03 | Colunas `quantidade_estoque`, `foto`, `content_type` em `cerveja` |
+| V04 | Tabelas `estado` e `cidade` |
+| V05–V06 | Tabela `cliente` |
+| V07–V11 | Tabelas `usuario`, `grupo`, `permissao`; usuário admin; permissões |
+| V12 | Tabelas `venda` e `item_venda` |
+| V13 | Role `ROLE_CANCELAR_VENDA` |
+| V14 | Estados e cidades do Brasil |
+| V15 | Dados de demonstração: 2 vendedores, 3 clientes, 10 cervejas, 24 vendas |
+
+## CI/CD
+
+- **GitHub Actions** — análise estática de segurança (OSSAR) em push/PR para `master`
+- **Dependabot** — atualizações automáticas de dependências Maven e npm
 - Spring MVC 5.x → Spring Boot 3.2.5
 - javax.* → jakarta.* (Jakarta EE)
 - Hibernate Criteria API → JPA Criteria API

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,56 +1,67 @@
 # Security Policy
 
-## Supported Versions
+## Versões Suportadas
 
-This repository is maintained as a study project and does not have multiple
-supported release branches.
+Este é um projeto de estudo/portfólio. Apenas o branch `master` recebe correções de segurança.
 
-| Version | Supported |
-| ------- | --------- |
-| master  | Yes       |
-| Older branches or forks | No |
+| Versão / Branch | Suportada |
+|---|---|
+| `master` | ✅ Sim |
+| Branches antigas ou forks | ❌ Não |
 
-## Reporting a Vulnerability
+## Reportando uma Vulnerabilidade
 
-If you believe you have found a security vulnerability, do not open a public
-issue.
+**Não abra uma issue pública** para relatar vulnerabilidades de segurança.
 
-Please use GitHub's private vulnerability reporting flow for this repository:
+Use o fluxo de **reporte privado** do GitHub:
 
-- Open the repository Security tab.
-- Use Report a vulnerability to submit the details privately.
+1. Acesse a aba **Security** do repositório
+2. Clique em **Report a vulnerability**
+3. Descreva o problema com o máximo de detalhes
 
-When reporting, include:
+Ao reportar, inclua:
+- Descrição clara da vulnerabilidade e área afetada
+- Passos para reprodução ou prova de conceito
+- Avaliação de impacto (se conhecida)
+- Sugestão de correção (se disponível)
 
-- A clear description of the issue and affected area.
-- Reproduction steps or a proof of concept.
-- Impact assessment, if known.
-- Suggested remediation, if available.
+**Prazo de resposta esperado:** confirmação inicial em até 5 dias úteis.
 
-Best effort response targets:
+Por favor, evite divulgação pública até que o problema tenha sido revisado e uma correção ou mitigação esteja disponível.
 
-- Initial acknowledgement within 5 business days.
-- Follow-up after triage when the report is validated.
+---
 
-Please avoid public disclosure until the issue has been reviewed and a fix or
-mitigation is available.# Security Policy
+## Práticas de Segurança do Projeto
 
-## Supported Versions
+### Autenticação e Autorização
+- Autenticação via **form login** com Spring Security 6
+- Senhas armazenadas com **BCrypt** (fator de custo padrão do Spring Security)
+- Controle de acesso baseado em **roles** (`ROLE_CADASTRAR_CIDADE`, `ROLE_CADASTRAR_USUARIO`, `ROLE_CANCELAR_VENDA`) e **grupos** (Administrador, Vendedor)
+- Proteção contra **CSRF** habilitada por padrão no Spring Security
+- Cabeçalhos de segurança HTTP configurados via Spring Security (X-Content-Type-Options, X-Frame-Options, etc.)
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+### Banco de Dados
+- Migrations versionadas com **Flyway** — sem DDL automático em produção
+- Queries parametrizadas via **Spring Data JPA / JPQL** — sem SQL concatenado (proteção contra SQL Injection)
+- Credenciais do banco injetadas por **variáveis de ambiente** (nunca em código ou no repositório)
+- Arquivo `.env` listado no `.gitignore`
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+### Upload de Arquivos
+- Validação de tipo MIME em uploads de fotos de cervejas
+- Tamanho máximo configurado (10 MB)
+- Armazenamento em **AWS S3** (produção) ou diretório local — sem execução de arquivos enviados
 
-## Reporting a Vulnerability
+### Docker / Infraestrutura
+- Container da aplicação executa com **usuário não-root** (`brewer`)
+- Jar com permissões `644` (não executável diretamente pelo sistema)
+- Imagem de runtime baseada em `eclipse-temurin:17-jre` (Debian) — sem ferramentas de build na imagem final
+- Secrets via variáveis de ambiente no `docker-compose.yml` com suporte a arquivo `.env`
 
-Use this section to tell people how to report a vulnerability.
+### Dependências
+- **Dependabot** configurado para atualização automática de dependências Maven e npm
+- **GitHub Actions OSSAR** (análise estática de segurança) executa em cada push/PR para `master`
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+### O que NÃO está implementado (escopo de estudo)
+- HTTPS / TLS (esperado ser terminado no load balancer/proxy reverso)
+- Rate limiting / proteção contra brute force no login
+- Auditoria de ações (log de quem fez o quê)


### PR DESCRIPTION
## O que muda

### README.md — reescrita completa
- Tabelas de todas as tecnologias com versões reais (Spring Boot 3.2.5, Flyway 10.10.0, MariaDB 11.3, Angular 21.2.7…)
- Instruções de execução via **Docker** (método principal, com suporte ARM64/Raspberry Pi) e local (Maven + H2)
- Documentação de todos os perfis: `default` (H2), `prod` (MariaDB), `docker`
- Tabela completa de variáveis de ambiente do `docker-compose.yml` / `.env`
- Seção de controle de acesso: grupos (`Administrador`, `Vendedor`) e roles (`ROLE_CADASTRAR_CIDADE`, `ROLE_CADASTRAR_USUARIO`, `ROLE_CANCELAR_VENDA`)
- Tabela de todas as 15 migrations Flyway com descrições
- Seção de CI/CD (GitHub Actions OSSAR + Dependabot)
- API REST com endpoint de estatísticas de vendas

### SECURITY.md — reescrito e expandido
- Remove conteúdo duplicado e placeholder genérico do template GitHub
- Traduzido para português
- Documenta práticas implementadas: BCrypt, CSRF, JPQL (anti SQL Injection), `.env` no `.gitignore`, usuário não-root no Docker, Dependabot e OSSAR
- Seção explícita de limitações do escopo de estudo (sem HTTPS nativo, sem rate limiting, sem auditoria de ações)
