### PR TITLE
feat: adiciona instrumentação de observabilidade com Actuator + Micrometer OTLP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,13 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 <artifactId>junit-vintage-engine</artifactId>
 <scope>test</scope>
 </dependency>
-</dependencies>
 
-</project>
+        <!-- Observability: Actuator + Micrometer OTLP -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-otlp</artifactId>
+        </dependency>

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -35,3 +35,11 @@ aws.s3.bucket=${AWS_S3_BUCKET:}
 # ─── Logging ──────────────────────────────────────────────────────────────────
 logging.level.root=INFO
 logging.level.com.algaworks.brewer=INFO
+
+# ─── Observability / Actuator ─────────────────────────────────────────────────
+management.endpoints.web.exposure.include=health,info,metrics
+management.endpoint.health.show-details=always
+# Exporta métricas via OTLP para o OTel Collector (override pela env OTEL_EXPORTER_OTLP_ENDPOINT)
+management.otlp.metrics.export.enabled=true
+management.otlp.metrics.export.url=${OTEL_EXPORTER_OTLP_ENDPOINT:http://otel-collector:4318}/v1/metrics
+management.otlp.metrics.export.step=30s

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,6 +48,12 @@ aws.s3.bucket=
 # Mail Configuration (optional)
 mail.username=
 mail.password=
+
+# ─── Observability / Actuator ─────────────────────────────────────────────────
+management.endpoints.web.exposure.include=health,info,metrics
+management.endpoint.health.show-details=always
+# OTLP desabilitado no perfil de desenvolvimento local
+management.otlp.metrics.export.enabled=false
 mail.host=smtp.sendgrid.net
 mail.port=587
 


### PR DESCRIPTION
## O que muda

Adiciona instrumentação de observabilidade ao Brewer para integração com o stack OpenTelemetry + Prometheus + Grafana.

### Dependências adicionadas (`pom.xml`)

- `spring-boot-starter-actuator` — expõe endpoints de saúde e métricas
- `micrometer-registry-otlp` — exporta métricas no formato OTLP para o OTel Collector

### Configurações

| Perfil | Arquivo | Comportamento |
|---|---|---|
| Local/Dev | `application.properties` | Actuator habilitado, exportação OTLP **desligada** |
| Docker/Prod | `application-docker.properties` | Exportação OTLP **ligada**, aponta para `otel-collector:4318` |

A URL do collector pode ser sobrescrita via variável de ambiente `OTEL_EXPORTER_OTLP_ENDPOINT`.

### Endpoints disponíveis após deploy

- `GET /actuator/health`
- `GET /actuator/metrics`
- `GET /actuator/metrics/{nome}`

### Integração

O stack de observabilidade (`observability-epo`) já está configurado para receber métricas OTLP na porta `4318` do OTel Collector e repassá-las ao Prometheus.