### PR TITLE
Fix venda item event binding and cerveja reference handling

### DIFF
--- a/src/main/java/com/algaworks/brewer/Service/CadastroVendaService.java
+++ b/src/main/java/com/algaworks/brewer/Service/CadastroVendaService.java
@@ -13,6 +13,7 @@ import com.algaworks.brewer.Service.event.venda.CancelaVendaEvent;
 import com.algaworks.brewer.Service.event.venda.VendaEvent;
 import com.algaworks.brewer.model.StatusVenda;
 import com.algaworks.brewer.model.Venda;
+import com.algaworks.brewer.repository.Cervejas;
 import com.algaworks.brewer.repository.Vendas;
 
 @Service
@@ -20,6 +21,9 @@ public class CadastroVendaService {
 
 	@Autowired
 	private Vendas vendas;
+
+	@Autowired
+	private Cervejas cervejas;
 	
 	@Autowired
 	private ApplicationEventPublisher publisher;
@@ -49,6 +53,9 @@ public class CadastroVendaService {
 //			tem de verificar um metodo de retornar msg para o usuario na tela*/
 //		}
 		
+		venda.getItens().forEach(item ->
+				item.setCerveja(cervejas.getReferenceById(item.getCerveja().getCodigo())));
+
 		return vendas.saveAndFlush(venda); /*o metodo saveAndFlush ao realizar o salvamento no BD, 
 		retorna o resultado para o objeto que chama o metodo*/
 	}

--- a/src/main/java/com/algaworks/brewer/model/Cerveja.java
+++ b/src/main/java/com/algaworks/brewer/model/Cerveja.java
@@ -98,7 +98,7 @@ public class Cerveja implements Serializable {
 	private String urlThumbnailFoto;
 	
 
-	@PrePersist @PreUpdate @PostLoad
+	@PrePersist @PreUpdate
 	private void prePersistUpdate() {
 		sku = sku.toUpperCase();
 	}

--- a/src/main/resources/static/javascripts/venda.tabela-itens.js
+++ b/src/main/resources/static/javascripts/venda.tabela-itens.js
@@ -12,7 +12,7 @@ Brewer.TabelaItens = (function() {
 		this.autocomplete.on('item-selecionado', onItemSelecionado.bind(this));
 		
 		bindQuantidade.call(this);
-		bindTabelaItem.call(this);
+		bindTabelaItemDelegado.call(this);
 	}
 	
 	TabelaItens.prototype.valorTotal = function() {
@@ -37,7 +37,7 @@ Brewer.TabelaItens = (function() {
 		
 		bindQuantidade.call(this);
 		
-		var tabelaItem = bindTabelaItem.call(this); 
+		var tabelaItem = $('.js-tabela-item'); 
 		this.emitter.trigger('tabela-itens-atualizada', tabelaItem.data('valor-total'));
 	}
 	
@@ -86,11 +86,9 @@ Brewer.TabelaItens = (function() {
 	}
 	
 
-	function bindTabelaItem() {
-		var tabelaItem = $('.js-tabela-item');
-		$('body').on('.js-tabela-item', 'dblclick', onDoubleClick);
-		$('body').on('.js-tabela-item', '.js-exclusao-item-btn').on('click', onExclusaoItemClick.bind(this));
-		return tabelaItem;
+	function bindTabelaItemDelegado() {
+		$('body').on('dblclick', '.js-tabela-item', onDoubleClick);
+		$('body').on('click', '.js-exclusao-item-btn', onExclusaoItemClick.bind(this));
 	}
 		
 	return TabelaItens;


### PR DESCRIPTION
## Resumo
Corrige inconsistências no fluxo de itens da venda no frontend e no vínculo de entidade `Cerveja` no salvamento da venda no backend.

## O que mudou
- Corrigido o binding de eventos delegados em `venda.tabela-itens.js` para:
  - usar assinatura correta do `on` em eventos delegados (`dblclick` e `click`)
  - evitar rebind incorreto ao atualizar a tabela
- Ajustado `CadastroVendaService` para anexar referências gerenciadas de `Cerveja` via `getReferenceById` antes de persistir `Venda`.
- Removido `@PostLoad` de `Cerveja.prePersistUpdate()` para evitar alteração desnecessária de estado ao carregar entidade.

## Impacto
- Evita falhas/intermitência na exclusão/edição de itens da venda via tabela dinâmica.
- Reduz risco de problemas de persistência por entidades destacadas em itens da venda.

## Validação
- `mvn -q -DskipTests compile` executado com sucesso.
- `docker compose config -q` executado com sucesso.
