### PR TITLE
feat: add dedicated test profile using MariaDB brewer_test schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 <plugin>
 <groupId>org.apache.maven.plugins</groupId>
 <artifactId>maven-surefire-plugin</artifactId>
+<configuration>
+<systemPropertyVariables>
+<spring.profiles.active>test</spring.profiles.active>
+</systemPropertyVariables>
+</configuration>
 </plugin>
 </plugins>
 </build>

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,20 @@
+# Test profile: isolated from default/dev configuration
+
+# Dedicated MariaDB database for tests, aligned with production runtime
+spring.datasource.url=jdbc:mariadb://localhost:3306/brewer_test?createDatabaseIfNotExist=true
+spring.datasource.driverClassName=org.mariadb.jdbc.Driver
+spring.datasource.username=brewer
+spring.datasource.password=brewer
+
+# Keep schema lifecycle under Flyway in tests
+spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
+spring.jpa.hibernate.ddl-auto=none
+
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.clean-disabled=true
+
+# Keep test logs concise
+spring.jpa.show-sql=false
+logging.level.org.springframework=INFO
+logging.level.com.algaworks.brewer=INFO


### PR DESCRIPTION
## Motivação

Os testes de backend falhavam porque o H2 2.x é incompatível com a sintaxe MySQL das migrations Flyway (BIGINT(20), ENGINE=InnoDB).

## Mudanças

- **pom.xml**: configura maven-surefire-plugin para ativar o perfil Spring `test` automaticamente em toda execução de testes
- **src/test/resources/application-test.properties**: datasource apontando para `brewer_test` (MariaDB), substituindo H2

## Como provisionar o banco de testes

Ver branch `docs/test-db-bootstrap` para o script SQL de bootstrap.

## Resultado

`mvn test` → Tests run: 12, Failures: 0, Errors: 0, **BUILD SUCCESS**