### PR TITLE
docs: add test database bootstrap script and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,20 @@ npx playwright install
 npm test
 ```
 
+### Banco de testes para profile test
+
+Para provisionar o schema de testes e permissões em um servidor novo:
+
+```bash
+docker compose exec -T db mariadb -uroot -proot < docs/sql/bootstrap-test-db.sql
+```
+
+Depois execute os testes do backend:
+
+```bash
+mvn test
+```
+
 ## Configuração
 
 ### Perfis de Aplicação

--- a/docs/sql/bootstrap-test-db.sql
+++ b/docs/sql/bootstrap-test-db.sql
@@ -1,0 +1,14 @@
+-- Bootstrap do banco de testes para o profile `test`
+-- Execute com um usuário administrativo (ex.: root no container MariaDB)
+
+CREATE DATABASE IF NOT EXISTS brewer_test
+  CHARACTER SET utf8mb4
+  COLLATE utf8mb4_unicode_ci;
+
+CREATE USER IF NOT EXISTS 'brewer'@'%' IDENTIFIED BY 'brewer';
+CREATE USER IF NOT EXISTS 'brewer'@'localhost' IDENTIFIED BY 'brewer';
+
+GRANT ALL PRIVILEGES ON brewer_test.* TO 'brewer'@'%';
+GRANT ALL PRIVILEGES ON brewer_test.* TO 'brewer'@'localhost';
+
+FLUSH PRIVILEGES;


### PR DESCRIPTION
## Mudanças

- **docs/sql/bootstrap-test-db.sql**: script SQL para provisionar o schema `brewer_test` e conceder privilégios ao usuário `brewer` em qualquer instância MariaDB
- **README.md**: nova seção *Banco de Testes* com instruções para executar o script antes de rodar `mvn test`

## Como usar

```bash
docker compose exec -T db mariadb -uroot -proot < docs/sql/bootstrap-test-db.sql
mvn test
```