### PR TITLE
Harden security defaults and remove legacy default admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ docker compose up --build
 # http://localhost:8081
 ```
 
-O Flyway aplica automaticamente as migrations V01–V15 na primeira inicialização, incluindo dados de demonstração (2 vendedores, 3 clientes, 10 cervejas e 24 vendas).
+O Flyway aplica automaticamente as migrations V01–V16 na primeira inicialização, incluindo dados de demonstração (2 vendedores, 3 clientes, 10 cervejas e 24 vendas).
 
-**Credenciais padrão:** `admin@brewer.com` / `admin123`
+Por hardening de segurança, não há mais credencial administrativa padrão ativa após as migrations.
+Para criar um admin local manualmente, use o script `docs/sql/bootstrap-local-admin.sql`.
 
 ### Serviços Docker
 
@@ -164,6 +165,14 @@ Depois execute os testes do backend:
 mvn test
 ```
 
+### Bootstrap manual de admin local
+
+Para ambientes locais, gere um hash BCrypt, ajuste nome/e-mail e execute:
+
+```bash
+docker compose exec -T db mariadb -uroot -proot brewer < docs/sql/bootstrap-local-admin.sql
+```
+
 ## Configuração
 
 ### Perfis de Aplicação
@@ -220,6 +229,7 @@ O sistema usa grupos e permissões granulares:
 | V13 | Role `ROLE_CANCELAR_VENDA` |
 | V14 | Estados e cidades do Brasil |
 | V15 | Dados de demonstração: 2 vendedores, 3 clientes, 10 cervejas, 24 vendas |
+| V16 | Desativa usuário admin padrão legado e remove vínculo administrativo (hardening) |
 
 ## CI/CD
 

--- a/docs/sql/bootstrap-local-admin.sql
+++ b/docs/sql/bootstrap-local-admin.sql
@@ -1,0 +1,25 @@
+-- Bootstrap manual de um administrador local (uso em desenvolvimento).
+-- 1) Gere um hash BCrypt e substitua o valor em @admin_hash.
+-- 2) Ajuste nome/email se desejar.
+-- 3) Execute no banco alvo.
+
+SET @admin_nome  = 'brewer';
+SET @admin_email = 'brewer@brewer.com';
+SET @admin_hash  = '$2a$10$ZjtZblwv5OsmfDTIWO9ZiuuYDVv8vqNKirhhkj94U8Vz.zgBj3soK';
+
+INSERT INTO usuario (nome, email, senha, ativo)
+SELECT @admin_nome, @admin_email, @admin_hash, 1
+WHERE NOT EXISTS (
+  SELECT 1 FROM usuario WHERE email = @admin_email
+);
+
+INSERT INTO usuario_grupo (codigo_usuario, codigo_grupo)
+SELECT u.codigo, 1
+FROM usuario u
+WHERE u.email = @admin_email
+  AND NOT EXISTS (
+    SELECT 1
+    FROM usuario_grupo ug
+    WHERE ug.codigo_usuario = u.codigo
+      AND ug.codigo_grupo = 1
+  );

--- a/docs/sql/bootstrap-local-admin.sql
+++ b/docs/sql/bootstrap-local-admin.sql
@@ -3,9 +3,9 @@
 -- 2) Ajuste nome/email se desejar.
 -- 3) Execute no banco alvo.
 
-SET @admin_nome  = 'brewer';
-SET @admin_email = 'brewer@brewer.com';
-SET @admin_hash  = '$2a$10$ZjtZblwv5OsmfDTIWO9ZiuuYDVv8vqNKirhhkj94U8Vz.zgBj3soK';
+SET @admin_nome  = 'Admin Local';
+SET @admin_email = 'admin@local';
+SET @admin_hash  = 'SUBSTITUIR_POR_HASH_BCRYPT';
 
 INSERT INTO usuario (nome, email, senha, ativo)
 SELECT @admin_nome, @admin_email, @admin_hash, 1

--- a/src/main/java/com/algaworks/brewer/config/SecurityConfig.java
+++ b/src/main/java/com/algaworks/brewer/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.algaworks.brewer.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -17,20 +18,33 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 @EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
+	private final Environment environment;
+
+	public SecurityConfig(Environment environment) {
+		this.environment = environment;
+	}
+
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		boolean allowH2Console = isH2ConsoleAllowed();
+
 		http
-			.authorizeHttpRequests(authorize -> authorize
-				.requestMatchers("/layout/**", "/images/**", "/stylesheets/**", "/static/**").permitAll()
-				.requestMatchers("/h2-console/**").permitAll()
-				.requestMatchers("/actuator/**").permitAll()
-				.requestMatchers("/cidades/novo").hasRole("CADASTRAR_CIDADE")
-				.requestMatchers("/usuarios/**").hasRole("CADASTRAR_USUARIO")
-				.requestMatchers("/api/estados").permitAll()
-				.requestMatchers("/api/cervejas/search").permitAll()
-				.requestMatchers("/api/**").authenticated()
-				.anyRequest().authenticated()
-			)
+			.authorizeHttpRequests(authorize -> {
+				authorize
+					.requestMatchers("/layout/**", "/images/**", "/stylesheets/**", "/static/**").permitAll()
+					.requestMatchers("/actuator/health", "/actuator/info").permitAll()
+					.requestMatchers("/actuator/**").authenticated()
+					.requestMatchers("/cidades/novo").hasRole("CADASTRAR_CIDADE")
+					.requestMatchers("/usuarios/**").hasRole("CADASTRAR_USUARIO")
+					.requestMatchers("/api/estados").permitAll()
+					.requestMatchers("/api/cervejas/search").permitAll()
+					.requestMatchers("/api/**").authenticated()
+					.anyRequest().authenticated();
+
+				if (allowH2Console) {
+					authorize.requestMatchers("/h2-console/**").permitAll();
+				}
+			})
 			.formLogin(form -> form
 				.loginPage("/login")
 				.permitAll()
@@ -44,14 +58,25 @@ public class SecurityConfig {
 			.sessionManagement(session -> session
 				.invalidSessionUrl("/login")
 			)
-			.csrf(csrf -> csrf
-				.ignoringRequestMatchers("/api/**", "/h2-console/**")
-			)
-			.headers(headers -> headers
-				.frameOptions(frame -> frame.sameOrigin())
-			);
+			.csrf(csrf -> {
+				csrf.ignoringRequestMatchers("/api/**");
+				if (allowH2Console) {
+					csrf.ignoringRequestMatchers("/h2-console/**");
+				}
+			})
+			.headers(headers -> {
+				if (allowH2Console) {
+					headers.frameOptions(frame -> frame.sameOrigin());
+				}
+			});
 		
 		return http.build();
+	}
+
+	private boolean isH2ConsoleAllowed() {
+		boolean h2ConsoleEnabled = Boolean.parseBoolean(environment.getProperty("spring.h2.console.enabled", "false"));
+		boolean localProfile = environment.matchesProfiles("dev", "local", "test");
+		return h2ConsoleEnabled && localProfile;
 	}
 
 	@Bean

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -38,7 +38,7 @@ logging.level.com.algaworks.brewer=INFO
 
 # ─── Observability / Actuator ─────────────────────────────────────────────────
 management.endpoints.web.exposure.include=health,info,metrics,prometheus
-management.endpoint.health.show-details=always
+management.endpoint.health.show-details=when_authorized
 # Exporta métricas via OTLP para o OTel Collector (override pela env OTEL_EXPORTER_OTLP_ENDPOINT)
 management.otlp.metrics.export.enabled=true
 management.otlp.metrics.export.url=${OTEL_EXPORTER_OTLP_ENDPOINT:http://otel-collector:4318}/v1/metrics

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,12 +51,8 @@ mail.password=
 
 # ─── Observability / Actuator ─────────────────────────────────────────────────
 management.endpoints.web.exposure.include=health,info,metrics
-management.endpoint.health.show-details=always
+management.endpoint.health.show-details=when_authorized
 # OTLP desabilitado no perfil de desenvolvimento local
 management.otlp.metrics.export.enabled=false
 mail.host=smtp.sendgrid.net
 mail.port=587
-
-# Security Configuration
-spring.security.user.name=admin
-spring.security.user.password=admin

--- a/src/main/resources/db/migration/V16__remover_usuario_admin_padrao.sql
+++ b/src/main/resources/db/migration/V16__remover_usuario_admin_padrao.sql
@@ -1,0 +1,12 @@
+-- Endurece o admin padrão legado sem quebrar FKs (ex.: vendas históricas).
+-- Estratégia: remove vínculo com grupo administrador e desativa a conta.
+DELETE FROM usuario_grupo
+WHERE codigo_grupo = 1
+  AND codigo_usuario IN (
+    SELECT codigo FROM usuario WHERE email = 'admin@brewer.com'
+  );
+
+UPDATE usuario
+SET ativo = 0,
+    email = CONCAT('admin_desativado_', codigo, '@invalid.local')
+WHERE email = 'admin@brewer.com';


### PR DESCRIPTION
## Summary
This PR hardens security defaults and removes dependence on a legacy fixed admin account.

## What changed
- Restricted access to sensitive endpoints in SecurityConfig:
  - `/actuator/health` and `/actuator/info` remain public
  - other `/actuator/**` endpoints now require authentication
  - `/h2-console/**` is only allowed when H2 console is enabled and profile is local/dev/test
- Tightened CSRF/frame options handling around H2 console based on the same local condition
- Removed Spring Security default credentials from `application.properties`
- Changed Actuator health details visibility to `when_authorized` (local and docker profiles)
- Added Flyway migration `V16` to harden legacy admin account safely (without FK breakage):
  - removes admin group binding
  - deactivates account and rewrites email to non-routable local value
- Added `docs/sql/bootstrap-local-admin.sql` template to create a local admin manually
- Updated README with the new hardened flow and migration notes

## Validation
- Manual login flow tested against running app (`/login`) with CSRF token handling and expected redirect to `/` on success
- Database verified after migration: `V16` applied successfully and legacy admin account deactivated

## Notes
- The bootstrap SQL remains a template with placeholders to avoid committing user-specific credential material.