### PR TITLE
Add E2E lockfile and automate Java dependency auditing

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,50 @@
+name: Dependency Check
+
+"on":
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '30 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Cache Dependency-Check data
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/org/owasp
+          key: dependency-check-${{ runner.os }}-${{ hashFiles('pom.xml') }}
+          restore-keys: |
+            dependency-check-${{ runner.os }}-
+
+      - name: Run OWASP Dependency-Check
+        env:
+          NVD_API_KEY: ${{ secrets['NVD_API_KEY'] }}
+        run: mvn -B -DskipTests dependency-check:check
+
+      - name: Upload Dependency-Check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: target/dependency-check-report.html
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ npx playwright install
 npm test
 ```
 
+O diretório E2E agora mantém lockfile para auditorias reproduzíveis de dependências via `npm audit`.
+
 ### Banco de testes para profile test
 
 Para provisionar o schema de testes e permissões em um servidor novo:
@@ -234,7 +236,19 @@ O sistema usa grupos e permissões granulares:
 ## CI/CD
 
 - **GitHub Actions** — análise estática de segurança (OSSAR) em push/PR para `master`
+- **GitHub Actions** — auditoria Java com OWASP Dependency-Check em push/PR/schedule
 - **Dependabot** — atualizações automáticas de dependências Maven e npm
+
+### Auditoria Java de dependências
+
+Execução local:
+
+```bash
+mvn -B -DskipTests dependency-check:check
+```
+
+Para melhor desempenho e menos rate limiting, configure a variável de ambiente `NVD_API_KEY` localmente ou o secret `NVD_API_KEY` no GitHub Actions.
+O relatório HTML é gerado em `target/dependency-check-report.html`.
 - Spring MVC 5.x → Spring Boot 3.2.5
 - javax.* → jakarta.* (Jakarta EE)
 - Hibernate Criteria API → JPA Criteria API

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,96 @@
+{
+  "name": "brewer-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "brewer-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.40.0",
+        "@types/node": "^25.6.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 <java.version>17</java.version>
 
+<!-- OWASP Dependency Check -->
+<dependency-check.version>12.2.1</dependency-check.version>
+
 <!-- Flyway -->
 <flyway.version>10.10.0</flyway.version>
 
@@ -75,6 +78,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 <systemPropertyVariables>
 <spring.profiles.active>test</spring.profiles.active>
 </systemPropertyVariables>
+</configuration>
+</plugin>
+
+<plugin>
+<groupId>org.owasp</groupId>
+<artifactId>dependency-check-maven</artifactId>
+<version>${dependency-check.version}</version>
+<configuration>
+<format>HTML</format>
+<failBuildOnCVSS>7</failBuildOnCVSS>
+<nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
 </configuration>
 </plugin>
 </plugins>


### PR DESCRIPTION
## Summary
This PR closes the remaining dependency-audit gaps by versioning the E2E lockfile and automating Java dependency scanning.

## What changed
- Added `e2e/package-lock.json` so E2E dependency resolution is reproducible and `npm audit` can run reliably
- Added OWASP Dependency-Check plugin configuration to `pom.xml`
- Added GitHub Actions workflow `.github/workflows/dependency-check.yml`
  - runs on push, PR, schedule and manual dispatch
  - uses Maven cache
  - accepts optional `NVD_API_KEY` secret for faster NVD updates
  - uploads HTML report as artifact
- Updated `README.md` with E2E lockfile note and Java dependency audit instructions

## Validation
- `npm audit --json` in `e2e/`: 0 vulnerabilities
- `mvn -DskipTests help:effective-pom -Doutput=/tmp/brewer-effective-pom.xml`: success

## Note
- The editor still reports a warning on `secrets['NVD_API_KEY']` in the workflow; this is a local validation false positive and does not block GitHub Actions execution.