### PR TITLE
Add VS Code extension pack and workspace recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    "vscjava.vscode-java-pack",
+    "vmware.vscode-boot-dev-pack",
+    "redhat.java",
+    "vscjava.vscode-maven",
+    "angular.ng-template",
+    "ms-playwright.playwright",
+    "ms-azuretools.vscode-docker",
+    "editorconfig.editorconfig"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "java.configuration.runtimes": [
+    {
+      "name": "JavaSE-21",
+      "path": "/home/dante/.sdkman/candidates/java/21-tem",
+      "default": true
+    }
+  ],
+  "java.configuration.updateBuildConfiguration": "automatic",
+  "java.import.maven.enabled": true,
+  "java.import.gradle.enabled": false,
+  "java.compile.nullAnalysis.mode": "automatic",
+  "maven.executable.path": "mvn",
+  "editor.formatOnSave": true
+}

--- a/vscode-extension-pack/.vscodeignore
+++ b/vscode-extension-pack/.vscodeignore
@@ -1,0 +1,2 @@
+.gitignore
+README.md

--- a/vscode-extension-pack/README.md
+++ b/vscode-extension-pack/README.md
@@ -1,0 +1,20 @@
+# Brewer Extension Pack
+
+Pacote de extensoes recomendado para desenvolvimento no projeto Brewer.
+
+## Extensoes incluidas
+
+- vscjava.vscode-java-pack
+- vmware.vscode-boot-dev-pack
+- redhat.java
+- vscjava.vscode-maven
+- angular.ng-template
+- ms-playwright.playwright
+- ms-azuretools.vscode-docker
+- editorconfig.editorconfig
+
+## Como usar
+
+1. Abra a pasta `vscode-extension-pack` no terminal.
+2. Execute `npx @vscode/vsce package` para gerar um `.vsix` local.
+3. No VS Code, use "Extensions: Install from VSIX..." para instalar.

--- a/vscode-extension-pack/package.json
+++ b/vscode-extension-pack/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "brewer-extension-pack",
+  "displayName": "Brewer Extension Pack",
+  "description": "Extension pack recomendada para desenvolvimento do projeto Brewer.",
+  "version": "0.0.1",
+  "publisher": "klaillton",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Extension Packs"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Klaillton/brewer.git"
+  },
+  "extensionPack": [
+    "vscjava.vscode-java-pack",
+    "vmware.vscode-boot-dev-pack",
+    "redhat.java",
+    "vscjava.vscode-maven",
+    "angular.ng-template",
+    "ms-playwright.playwright",
+    "ms-azuretools.vscode-docker",
+    "editorconfig.editorconfig"
+  ]
+}


### PR DESCRIPTION
## Summary
- add workspace-level VS Code settings for Java/Maven import and runtime
- add recommended extensions list in .vscode/extensions.json
- add a local extension-pack project under vscode-extension-pack with all recommended extensions

## Why
This reduces missing-configuration alerts in VS Code and provides a single package for onboarding developers quickly.
