### PR TITLE
fix: corrige java.jdt.ls.java.home para caminho Linux do JDK 21

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "java.jdt.ls.java.home": "/home/dante/.sdkman/candidates/java/21-tem",
   "java.configuration.runtimes": [
     {
       "name": "JavaSE-21",


### PR DESCRIPTION
Adiciona a propriedade `java.jdt.ls.java.home` no `.vscode/settings.json` apontando para o JDK 21 instalado via SDKMAN, corrigindo o alerta de caminho inacessível (C:\Program Files\Java\jdk-23).