### PR TITLE
feat: Kubernetes manifests, hardening e gestão segura de segredos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ Temporary Items
 .env
 .env.*
 !.env.example
+
+# Segredos locais para Kubernetes (nunca versionar)
+k8s/.secret.env
+k8s/.secret.*.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,17 @@ WORKDIR /app
 # Instala wget para o HEALTHCHECK e cria usuário não-root
 RUN apt-get update && apt-get install -y --no-install-recommends wget \
     && rm -rf /var/lib/apt/lists/* \
-    && addgroup --system brewer && adduser --system --ingroup brewer brewer
+  && groupadd -g 10001 brewer \
+  && useradd -u 10001 -g brewer -M -s /usr/sbin/nologin brewer \
+  && mkdir -p /tmp \
+  && chown -R brewer:brewer /tmp
 
 COPY --from=build /app/target/brewer.jar app.jar
 
 RUN chown brewer:brewer app.jar && \
     chmod 644 app.jar
+
+ENV JAVA_TOOL_OPTIONS="-Djava.io.tmpdir=/tmp"
 
 USER brewer
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────────────────────
+# deploy.sh — Build e deploy do Brewer no K3s local
+# ──────────────────────────────────────────────────────────────────────────────
+# Uso:
+#   ./deploy.sh             # build da imagem + deploy completo
+#   ./deploy.sh --skip-build  # apenas aplica os manifests (imagem já existe)
+#   ./deploy.sh --delete      # remove todos os recursos do namespace brewer
+#
+# Pré-requisitos:
+#   - docker instalado e com acesso ao daemon
+#   - kubectl configurado apontando para o cluster K3s
+#   - K3s usando docker como container runtime (docker://29.4.x)
+#   - namespace observability com otel-collector acessível em
+#     otel-collector.observability.svc.cluster.local:4318
+# ──────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+K8S_DIR="$PROJECT_ROOT/k8s"
+
+IMAGE_NAME="brewer"
+IMAGE_TAG="latest"
+NAMESPACE="brewer"
+SECRET_SCRIPT="$PROJECT_ROOT/scripts/rotate-k8s-secret.sh"
+SECRET_ENV_FILE="$PROJECT_ROOT/k8s/.secret.env"
+
+# ── Funções de log ────────────────────────────────────────────────────────────
+info()    { echo "[INFO]  $*"; }
+success() { echo "[OK]    $*"; }
+warn()    { echo "[WARN]  $*"; }
+error()   { echo "[ERROR] $*" >&2; exit 1; }
+
+# ── Argumento --delete ────────────────────────────────────────────────────────
+if [[ "${1:-}" == "--delete" ]]; then
+  warn "Removendo todos os recursos do namespace $NAMESPACE ..."
+  kubectl delete namespace "$NAMESPACE" --ignore-not-found
+  success "Namespace $NAMESPACE removido."
+  exit 0
+fi
+
+# ── Verificação de dependências ───────────────────────────────────────────────
+command -v docker  >/dev/null 2>&1 || error "docker não encontrado. Instale o Docker."
+command -v kubectl >/dev/null 2>&1 || error "kubectl não encontrado."
+
+# ── Secret (fora do repositório) ─────────────────────────────────────────────
+if [[ -f "$SECRET_ENV_FILE" ]]; then
+  info "Aplicando secret a partir de $SECRET_ENV_FILE ..."
+  "$SECRET_SCRIPT" --file "$SECRET_ENV_FILE"
+elif kubectl get secret brewer-secrets -n "$NAMESPACE" >/dev/null 2>&1; then
+  info "Secret brewer-secrets já existe no cluster."
+else
+  error "Secret brewer-secrets não encontrado. Crie k8s/.secret.env (base: k8s/.secret.env.example) e rode scripts/rotate-k8s-secret.sh"
+fi
+
+# ── Build da imagem Docker ────────────────────────────────────────────────────
+if [[ "${1:-}" != "--skip-build" ]]; then
+  info "Construindo imagem $IMAGE_NAME:$IMAGE_TAG ..."
+  docker build -t "$IMAGE_NAME:$IMAGE_TAG" "$PROJECT_ROOT"
+  success "Imagem construída: $IMAGE_NAME:$IMAGE_TAG"
+
+  # K3s usa docker como runtime neste servidor, então a imagem já está disponível
+  # no namespace do containerd via Docker socket compartilhado.
+  # Se o runtime fosse containerd puro, seria necessário:
+  #   docker save "$IMAGE_NAME:$IMAGE_TAG" | sudo k3s ctr images import -
+  info "Imagem disponível para K3s (runtime: docker)."
+fi
+
+# ── Aplicar manifests ─────────────────────────────────────────────────────────
+info "Aplicando manifests Kubernetes em $K8S_DIR ..."
+kubectl apply -k "$K8S_DIR"
+success "Manifests aplicados."
+
+# ── Aguardar MariaDB ficar pronto ─────────────────────────────────────────────
+info "Aguardando MariaDB ficar pronto ..."
+kubectl rollout status deployment/mariadb -n "$NAMESPACE" --timeout=180s
+success "MariaDB pronto."
+
+# ── Aguardar aplicação ficar pronta ──────────────────────────────────────────
+info "Aguardando aplicação brewer ficar pronta ..."
+kubectl rollout status deployment/brewer -n "$NAMESPACE" --timeout=300s
+success "Aplicação brewer pronta."
+
+# ── Resumo ────────────────────────────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════════════════════════"
+echo "  Deploy concluído com sucesso!"
+echo "══════════════════════════════════════════════════════════"
+echo ""
+kubectl get all -n "$NAMESPACE"
+echo ""
+echo "  Acesso à aplicação:"
+echo "    • Via Ingress (host): http://brewer.local"
+echo "      (adicione '192.168.1.101 brewer.local' ao /etc/hosts)"
+echo ""
+echo "  Observabilidade (acesso via port-forward):"
+echo "    kubectl port-forward svc/grafana    3000:3000 -n observability"
+echo "    kubectl port-forward svc/prometheus 9090:9090 -n observability"
+echo ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - mariadb_data:/var/lib/mysql
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 10s
@@ -25,7 +25,15 @@ services:
     container_name: brewer-app
     restart: unless-stopped
     ports:
-      - "8081:8080"
+      - "127.0.0.1:8081:8080"
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=64m
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 256
     environment:
       SPRING_PROFILES_ACTIVE: docker,prod
       DB_HOST: db

--- a/k8s/.secret.env.example
+++ b/k8s/.secret.env.example
@@ -1,0 +1,7 @@
+# Copie para k8s/.secret.env e preencha com valores reais
+# cp k8s/.secret.env.example k8s/.secret.env
+
+DB_ROOT_PASSWORD=troque-por-senha-forte-root
+DB_PASSWORD=troque-por-senha-forte-app
+DB_USER=brewer
+DB_NAME=brewer

--- a/k8s/app-deployment.yaml
+++ b/k8s/app-deployment.yaml
@@ -1,0 +1,116 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: brewer
+  namespace: brewer
+  labels:
+    app.kubernetes.io/name: brewer
+    app.kubernetes.io/part-of: brewer
+    app.kubernetes.io/version: "latest"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: brewer
+  template:
+    metadata:
+      labels:
+        app: brewer
+        app.kubernetes.io/name: brewer
+        app.kubernetes.io/part-of: brewer
+      annotations:
+        # Instrui o Prometheus a fazer scrape deste pod diretamente
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "8080"
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: brewer
+          # Imagem construída localmente via: docker build -t brewer:latest .
+          # Em ambiente K3s com docker como runtime, a imagem fica disponível
+          # automaticamente. Ver deploy.sh para o fluxo completo.
+          image: brewer:latest
+          # IfNotPresent evita pull de registry inexistente para imagem local
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            # ── Spring Profile ──────────────────────────────────────────────
+            - name: SPRING_PROFILES_ACTIVE
+              value: "docker,prod"
+            # ── Database ────────────────────────────────────────────────────
+            - name: DB_HOST
+              value: "mariadb.brewer.svc.cluster.local"
+            - name: DB_PORT
+              value: "3306"
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: brewer-secrets
+                  key: db-name
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: brewer-secrets
+                  key: db-user
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: brewer-secrets
+                  key: db-password
+            # ── Observability: OTel Collector no namespace observability ────
+            # DNS interno K8s: <service>.<namespace>.svc.cluster.local
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector.observability.svc.cluster.local:4318"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          startupProbe:
+            httpGet:
+              path: /login
+              port: 8080
+            failureThreshold: 12
+            periodSeconds: 20
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /login
+              port: 8080
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: 8080
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            # Dimensionado para Raspberry Pi 4 (4 GB RAM)
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/app-ingress.yaml
+++ b/k8s/app-ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: brewer
+  namespace: brewer
+  labels:
+    app.kubernetes.io/name: brewer
+    app.kubernetes.io/part-of: brewer
+spec:
+  # Traefik é o ingress controller padrão do K3s
+  ingressClassName: traefik
+  rules:
+    # Acesse via: http://brewer.local (adicionar ao /etc/hosts da máquina cliente)
+    # ou via IP direto: http://192.168.1.101 (com header Host: brewer.local)
+    - host: brewer.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: brewer
+                port:
+                  name: http

--- a/k8s/app-service.yaml
+++ b/k8s/app-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: brewer
+  namespace: brewer
+  labels:
+    app.kubernetes.io/name: brewer
+    app.kubernetes.io/part-of: brewer
+spec:
+  selector:
+    app: brewer
+  ports:
+    - port: 80
+      targetPort: 8080
+      name: http
+  type: ClusterIP

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Aplica todos os recursos do namespace brewer
+resources:
+  - namespace.yaml
+  - network-policy.yaml
+  - mariadb-pvc.yaml
+  - mariadb-deployment.yaml
+  - mariadb-service.yaml
+  - app-deployment.yaml
+  - app-service.yaml
+  - app-ingress.yaml

--- a/k8s/mariadb-deployment.yaml
+++ b/k8s/mariadb-deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb
+  namespace: brewer
+  labels:
+    app.kubernetes.io/name: mariadb
+    app.kubernetes.io/part-of: brewer
+spec:
+  replicas: 1
+  # Recria o pod antes de destruir o antigo (garante que o PVC não fique preso)
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+        app.kubernetes.io/name: mariadb
+        app.kubernetes.io/part-of: brewer
+    spec:
+      containers:
+        - name: mariadb
+          image: mariadb:11.3
+          ports:
+            - containerPort: 3306
+              name: mysql
+          env:
+            - name: MARIADB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: brewer-secrets
+                  key: db-root-password
+            - name: MARIADB_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: brewer-secrets
+                  key: db-name
+            - name: MARIADB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: brewer-secrets
+                  key: db-user
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: brewer-secrets
+                  key: db-password
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mysql
+          livenessProbe:
+            exec:
+              command: ["healthcheck.sh", "--connect", "--innodb_initialized"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command: ["healthcheck.sh", "--connect", "--innodb_initialized"]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: mariadb-data

--- a/k8s/mariadb-pvc.yaml
+++ b/k8s/mariadb-pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mariadb-data
+  namespace: brewer
+  labels:
+    app.kubernetes.io/name: mariadb
+    app.kubernetes.io/part-of: brewer
+spec:
+  accessModes:
+    - ReadWriteOnce
+  # K3s provisiona automaticamente via local-path-provisioner
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 2Gi

--- a/k8s/mariadb-service.yaml
+++ b/k8s/mariadb-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb
+  namespace: brewer
+  labels:
+    app.kubernetes.io/name: mariadb
+    app.kubernetes.io/part-of: brewer
+spec:
+  selector:
+    app: mariadb
+  ports:
+    - port: 3306
+      targetPort: 3306
+      name: mysql
+  # ClusterIP: banco não precisa ser exposto fora do cluster
+  type: ClusterIP

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: brewer
+  labels:
+    app.kubernetes.io/part-of: brewer

--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -1,0 +1,95 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: brewer
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-brewer-ingress
+  namespace: brewer
+spec:
+  podSelector:
+    matchLabels:
+      app: brewer
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - protocol: TCP
+          port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-mariadb-from-brewer
+  namespace: brewer
+spec:
+  podSelector:
+    matchLabels:
+      app: mariadb
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: brewer
+      ports:
+        - protocol: TCP
+          port: 3306
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-brewer-egress
+  namespace: brewer
+spec:
+  podSelector:
+    matchLabels:
+      app: brewer
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: mariadb
+      ports:
+        - protocol: TCP
+          port: 3306
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app: otel-collector
+      ports:
+        - protocol: TCP
+          port: 4318
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/k8s/observability/prometheus-patch.yaml
+++ b/k8s/observability/prometheus-patch.yaml
@@ -1,0 +1,50 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Patch no ConfigMap do Prometheus (namespace observability)
+# Adiciona scrape job para a aplicação brewer no namespace brewer.
+#
+# O Prometheus usa DNS interno do cluster para resolver o serviço:
+#   brewer.brewer.svc.cluster.local:80
+#
+# Aplicado via: kubectl apply -f k8s/observability/prometheus-patch.yaml
+# ──────────────────────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: observability
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+
+    scrape_configs:
+      # Coleta de saude do proprio Prometheus.
+      - job_name: prometheus
+        static_configs:
+          - targets: ['localhost:9090']
+
+      # Coleta metrics publicadas pelo OTel Collector.
+      # Porta 8889: metricas de aplicacao exportadas via OTel Prometheus exporter.
+      - job_name: otel-collector-metrics
+        static_configs:
+          - targets: ['otel-collector:8889']
+
+      # Porta 8888: metricas internas do proprio OTel Collector
+      # (spans recebidos, exportados, falhas, tamanho de fila, etc.).
+      - job_name: otel-collector-internal
+        static_configs:
+          - targets: ['otel-collector:8888']
+
+      # node-exporter: metricas do sistema operacional host
+      # (CPU, memoria, disco, rede, load average, filesystem).
+      - job_name: node-exporter
+        static_configs:
+          - targets: ['node-exporter:9100']
+
+      # Brewer: scrape direto do endpoint /actuator/prometheus da aplicacao.
+      # DNS interno K8s: <service>.<namespace>.svc.cluster.local
+      # A aplicacao expoe metricas via Micrometer + micrometer-registry-prometheus.
+      - job_name: brewer
+        metrics_path: '/actuator/prometheus'
+        static_configs:
+          - targets: ['brewer.brewer.svc.cluster.local:80']

--- a/scripts/rotate-k8s-secret.sh
+++ b/scripts/rotate-k8s-secret.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="brewer"
+SECRET_NAME="brewer-secrets"
+ENV_FILE="k8s/.secret.env"
+GENERATE="false"
+
+usage() {
+  cat <<'EOF'
+Uso:
+  scripts/rotate-k8s-secret.sh
+    Aplica/rotaciona o secret usando k8s/.secret.env
+
+  scripts/rotate-k8s-secret.sh --generate
+    Gera novas credenciais fortes em k8s/.secret.env e aplica no cluster
+
+  scripts/rotate-k8s-secret.sh --file caminho.env
+    Usa arquivo .env alternativo
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --generate)
+      GENERATE="true"
+      shift
+      ;;
+    --file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Argumento inválido: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$GENERATE" == "true" ]]; then
+  # Captura senha root ATUAL do cluster antes de gerar novas (necessário para ALTER USER)
+  OLD_ROOT_PASSWORD=""
+  if kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" &>/dev/null; then
+    OLD_ROOT_PASSWORD="$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" \
+      -o jsonpath='{.data.db-root-password}' | base64 -d)"
+  fi
+
+  mkdir -p "$(dirname "$ENV_FILE")"
+  DB_ROOT_PASSWORD="$(openssl rand -base64 36 | tr -d '\n' | tr '+/' 'Aa' | cut -c1-40)"
+  DB_PASSWORD="$(openssl rand -base64 36 | tr -d '\n' | tr '+/' 'Bb' | cut -c1-40)"
+  cat > "$ENV_FILE" <<EOF
+DB_ROOT_PASSWORD=$DB_ROOT_PASSWORD
+DB_PASSWORD=$DB_PASSWORD
+DB_USER=brewer
+DB_NAME=brewer
+EOF
+  chmod 600 "$ENV_FILE"
+  echo "[OK] Arquivo gerado: $ENV_FILE"
+fi
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "[ERRO] Arquivo não encontrado: $ENV_FILE" >&2
+  echo "Crie com base em k8s/.secret.env.example" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+: "${DB_ROOT_PASSWORD:?DB_ROOT_PASSWORD não definido}"
+: "${DB_PASSWORD:?DB_PASSWORD não definido}"
+: "${DB_USER:?DB_USER não definido}"
+: "${DB_NAME:?DB_NAME não definido}"
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+kubectl create secret generic "$SECRET_NAME" -n "$NAMESPACE" \
+  --from-literal=db-root-password="$DB_ROOT_PASSWORD" \
+  --from-literal=db-password="$DB_PASSWORD" \
+  --from-literal=db-user="$DB_USER" \
+  --from-literal=db-name="$DB_NAME" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "[OK] Secret $SECRET_NAME aplicado no namespace $NAMESPACE"
+
+# Se foi geração de novas credenciais, atualiza as senhas no MariaDB ANTES de reiniciar
+if [[ "${GENERATE:-false}" == "true" ]] && [[ -n "${OLD_ROOT_PASSWORD:-}" ]]; then
+  echo "[INFO] Atualizando senhas no MariaDB..."
+  MARIADB_POD="$(kubectl get pod -n "$NAMESPACE" -l app=mariadb \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+
+  if [[ -z "$MARIADB_POD" ]]; then
+    echo "[AVISO] Pod MariaDB não encontrado — senhas serão ativas após o próximo start do MariaDB" >&2
+  else
+    kubectl exec -n "$NAMESPACE" "$MARIADB_POD" -- \
+      mariadb -u root -p"${OLD_ROOT_PASSWORD}" -e \
+      "ALTER USER 'root'@'localhost' IDENTIFIED BY '${DB_ROOT_PASSWORD}';
+       ALTER USER '${DB_USER}'@'%' IDENTIFIED BY '${DB_PASSWORD}';
+       FLUSH PRIVILEGES;" \
+    && echo "[OK] Senhas atualizadas no MariaDB" \
+    || { echo "[ERRO] Falha ao atualizar senhas no MariaDB. Verifique manualmente." >&2; exit 1; }
+  fi
+fi
+
+echo "[INFO] Reiniciando deployments que usam o secret..."
+kubectl rollout restart deployment/mariadb -n "$NAMESPACE"
+kubectl rollout restart deployment/brewer -n "$NAMESPACE"
+kubectl rollout status deployment/mariadb -n "$NAMESPACE" --timeout=180s
+kubectl rollout status deployment/brewer -n "$NAMESPACE" --timeout=600s
+
+echo "[OK] Rotação concluída com sucesso"

--- a/src/main/java/com/algaworks/brewer/config/SecurityConfig.java
+++ b/src/main/java/com/algaworks/brewer/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
@@ -51,12 +52,16 @@ public class SecurityConfig {
 			)
 			.logout(logout -> logout
 				.logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
+				.invalidateHttpSession(true)
+				.clearAuthentication(true)
+				.deleteCookies("JSESSIONID")
 			)
 			.exceptionHandling(exception -> exception
 				.accessDeniedPage("/403")
 			)
 			.sessionManagement(session -> session
 				.invalidSessionUrl("/login")
+				.sessionFixation(sessionFixation -> sessionFixation.migrateSession())
 			)
 			.csrf(csrf -> {
 				csrf.ignoringRequestMatchers("/api/**");
@@ -65,8 +70,24 @@ public class SecurityConfig {
 				}
 			})
 			.headers(headers -> {
+				headers.contentTypeOptions(contentType -> {});
+				headers.referrerPolicy(referrer -> referrer.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN));
+				headers.permissionsPolicy(permissions -> permissions.policy("camera=(), geolocation=(), microphone=(), payment=(), usb=()"));
+				headers.contentSecurityPolicy(csp -> csp.policyDirectives(
+					"default-src 'self'; " +
+					"img-src 'self' data: https:; " +
+					"style-src 'self' 'unsafe-inline' https:; " +
+					"script-src 'self' 'unsafe-inline'; " +
+					"font-src 'self' data:; " +
+					"frame-ancestors 'self'; " +
+					"object-src 'none'; " +
+					"base-uri 'self'; " +
+					"form-action 'self'"
+				));
 				if (allowH2Console) {
 					headers.frameOptions(frame -> frame.sameOrigin());
+				} else {
+					headers.frameOptions(frame -> frame.deny());
 				}
 			});
 		

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -36,8 +36,16 @@ aws.s3.bucket=${AWS_S3_BUCKET:}
 logging.level.root=INFO
 logging.level.com.algaworks.brewer=INFO
 
+# ─── Hardening HTTP / Session ─────────────────────────────────────────────────
+server.error.include-message=never
+server.error.include-stacktrace=never
+server.servlet.session.cookie.http-only=true
+server.servlet.session.cookie.secure=true
+server.servlet.session.cookie.same-site=lax
+server.servlet.session.tracking-modes=cookie
+
 # ─── Observability / Actuator ─────────────────────────────────────────────────
-management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=when_authorized
 # Exporta métricas via OTLP para o OTel Collector (override pela env OTEL_EXPORTER_OTLP_ENDPOINT)
 management.otlp.metrics.export.enabled=true


### PR DESCRIPTION
## O que foi feito

### Kubernetes (K3s)
- Manifests completos: namespace, MariaDB (Deployment + PVC + Service), app (Deployment + Service + Ingress Traefik)
- `NetworkPolicy` default-deny + allow explícito mínimo (Traefik→app:8080, app→MariaDB:3306, app→OTel Collector:4318, DNS:53)
- `kustomization.yaml` como ponto de entrada — `secret.yaml` **excluído do repositório**
- `k8s/.secret.env.example`: template versionável para credenciais locais
- `k8s/observability/prometheus-patch.yaml`: scrape annotations para Prometheus

### Gestão segura de segredos
- `scripts/rotate-k8s-secret.sh`: criação e rotação segura do K8s Secret `brewer-secrets`
  - `--generate`: gera senhas fortes (openssl rand 40 chars), captura senha root atual, aplica `ALTER USER` no MariaDB com a senha antiga **antes** de reiniciar os pods, evitando Access Denied
- `k8s/.secret.env` adicionado ao `.gitignore`

### Hardening da aplicação
- **Dockerfile**: runtime com UID fixo 10001, `ENV JAVA_TOOL_OPTIONS` tmpdir
- **docker-compose.yml**: `read_only: true`, tmpfs `/tmp`, `cap_drop: ALL`, `no-new-privileges`, bind `127.0.0.1`
- **SecurityConfig.java**: CSP, Referrer-Policy, Permissions-Policy, `X-Frame-Options: DENY`, session fixation protection, logout seguro
- **application-docker.properties**: hardening HTTP/session, actuator reduzido a health+info, OTLP habilitado para OTel Collector

### Deploy
- `deploy.sh`: build Docker + `kubectl apply -k k8s/` + rollout com verificação de secret

## Validado em produção (K3s devserverpi)
- Ambos os pods `1/1 Running`, 0 restarts
- `curl -sSI -H 'Host: brewer.local' http://127.0.0.1/login` → `HTTP 200` com todos os headers de segurança
- Flyway 16 migrações executadas com sucesso
- NetworkPolicies ativas no cluster