### PR TITLE
fix: substitui StringUtils.isEmpty() depreciado por verificação nativa

### DIFF
--- a/src/main/java/com/algaworks/brewer/dto/CervejaDTO.java
+++ b/src/main/java/com/algaworks/brewer/dto/CervejaDTO.java
@@ -2,8 +2,6 @@ package com.algaworks.brewer.dto;
 
 import java.math.BigDecimal;
 
-import org.springframework.util.StringUtils;
-
 import com.algaworks.brewer.model.Origem;
 
 public class CervejaDTO {
@@ -28,7 +26,7 @@ public class CervejaDTO {
 		this.nome = nome;
 		this.origem = origem.getDescricao();
 		this.valor = valor;
-		this.foto = StringUtils.isEmpty(foto) ? "cerveja-mock.png" : foto;
+		this.foto = (foto == null || foto.isEmpty()) ? "cerveja-mock.png" : foto;
 	}
 
 	public Long getCodigo() {


### PR DESCRIPTION
## O que muda

Substitui o uso de `StringUtils.isEmpty(foto)` (método depreciado do Spring) pela verificação nativa `(foto == null || foto.isEmpty())` em `CervejaDTO`.

## Por que
`StringUtils.isEmpty()` foi depreciado no Spring 5 e removido no Spring 6/Boot 3. A verificação nativa é equivalente e sem dependência de framework.

## Arquivo alterado
- `src/main/java/com/algaworks/brewer/dto/CervejaDTO.java`