### PR TITLE
feat: configure HTTPS with Nginx and cert-manager TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ Temporary Items
 # Segredos locais para Kubernetes (nunca versionar)
 k8s/.secret.env
 k8s/.secret.*.env
+
+# Certificados TLS de desenvolvimento (gerados por scripts/generate-dev-certs.sh)
+nginx/certs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,25 @@
 services:
 
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: brewer-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/certs:/etc/nginx/certs:ro
+    depends_on:
+      app:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "https://localhost/actuator/health", "--no-check-certificate"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 70s
+
   db:
     image: mariadb:11.3
     container_name: brewer-db
@@ -24,6 +44,8 @@ services:
     build: .
     container_name: brewer-app
     restart: unless-stopped
+    # Porta exposta apenas para acesso direto de debug; o tráfego externo
+    # passa pelo Nginx (443 → app:8080). Remova se não precisar de acesso HTTP direto.
     ports:
       - "127.0.0.1:8081:8080"
     read_only: true

--- a/k8s/app-ingress.yaml
+++ b/k8s/app-ingress.yaml
@@ -6,12 +6,23 @@ metadata:
   labels:
     app.kubernetes.io/name: brewer
     app.kubernetes.io/part-of: brewer
+  annotations:
+    # cert-manager emite o certificado TLS via CA local confiável (brewer-local-ca-issuer).
+    # Para Let's Encrypt, troque por "letsencrypt-prod" (ver cert-manager-issuer.yaml).
+    cert-manager.io/cluster-issuer: brewer-local-ca-issuer
+    # Redireciona HTTP → HTTPS via Traefik middleware
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   # Traefik é o ingress controller padrão do K3s
   ingressClassName: traefik
+  tls:
+    - hosts:
+        - brewer.local
+      # cert-manager armazena o certificado gerado neste Secret
+      secretName: brewer-tls
   rules:
-    # Acesse via: http://brewer.local (adicionar ao /etc/hosts da máquina cliente)
-    # ou via IP direto: http://192.168.1.101 (com header Host: brewer.local)
+    # Acesse via: https://brewer.local (adicionar ao /etc/hosts da máquina cliente)
     - host: brewer.local
       http:
         paths:

--- a/k8s/cert-manager-issuer.yaml
+++ b/k8s/cert-manager-issuer.yaml
@@ -1,0 +1,144 @@
+# ─── cert-manager: CA local confiável para brewer.local ───────────────────────
+#
+# Estratégia em 3 passos:
+#   1. selfsigned-bootstrapper → emite o certificado da CA local
+#   2. brewer-local-ca (Certificate) → o certificado raiz da CA, guardado
+#      no namespace cert-manager (exigido por ClusterIssuer do tipo CA)
+#   3. brewer-local-ca-issuer (ClusterIssuer) → assina os certificados do servidor
+#
+# Pré-requisito: cert-manager instalado no cluster.
+# Para K3s:
+#   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+#   kubectl wait --namespace cert-manager --for=condition=ready pod \
+#     --selector=app.kubernetes.io/instance=cert-manager --timeout=120s
+#
+# Para confiar no certificado no browser/sistema operacional, veja o script:
+#   scripts/trust-dev-ca.sh
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ─── 1. Bootstrapper (autoassinado, apenas para criar a CA) ───────────────────
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-bootstrapper
+  labels:
+    app.kubernetes.io/part-of: brewer
+spec:
+  selfSigned: {}
+
+---
+# ─── 2. Certificado raiz da CA local ─────────────────────────────────────────
+# Fica no namespace cert-manager porque o ClusterIssuer CA lê de lá.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: brewer-local-ca
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/part-of: brewer
+spec:
+  isCA: true
+  commonName: "Brewer Local CA"
+  subject:
+    organizations:
+      - Brewer Dev
+  secretName: brewer-local-ca-tls
+  duration: 87600h   # 10 anos
+  renewBefore: 720h  # renova 30 dias antes de expirar
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: selfsigned-bootstrapper
+    kind: ClusterIssuer
+    group: cert-manager.io
+
+---
+# ─── 3. CA Issuer — assina certificados de servidor ──────────────────────────
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: brewer-local-ca-issuer
+  labels:
+    app.kubernetes.io/part-of: brewer
+spec:
+  ca:
+    # Segredo gerado pelo Certificate acima (namespace cert-manager)
+    secretName: brewer-local-ca-tls
+
+---
+# ─── Let's Encrypt Staging (testes com domínio real) ─────────────────────────
+# Descomente, ajuste o campo "email" e troque a anotação do Ingress para usar.
+#
+# apiVersion: cert-manager.io/v1
+# kind: ClusterIssuer
+# metadata:
+#   name: letsencrypt-staging
+# spec:
+#   acme:
+#     server: https://acme-staging-v02.api.letsencrypt.org/directory
+#     email: seu-email@exemplo.com
+#     privateKeySecretRef:
+#       name: letsencrypt-staging-key
+#     solvers:
+#       - http01:
+#           ingress:
+#             ingressClassName: traefik
+
+---
+# ─── Let's Encrypt Produção (domínio real) ────────────────────────────────────
+# Descomente e ajuste quando o app estiver em produção com domínio público.
+#
+# apiVersion: cert-manager.io/v1
+# kind: ClusterIssuer
+# metadata:
+#   name: letsencrypt-prod
+# spec:
+#   acme:
+#     server: https://acme-v02.api.letsencrypt.org/directory
+#     email: seu-email@exemplo.com
+#     privateKeySecretRef:
+#       name: letsencrypt-prod-key
+#     solvers:
+#       - http01:
+#           ingress:
+#             ingressClassName: traefik
+
+
+---
+# ─── Let's Encrypt Staging (testes com domínio real) ─────────────────────────
+# Descomente, ajuste o campo "email" e troque o host no Ingress para usar.
+#
+# apiVersion: cert-manager.io/v1
+# kind: ClusterIssuer
+# metadata:
+#   name: letsencrypt-staging
+# spec:
+#   acme:
+#     server: https://acme-staging-v02.api.letsencrypt.org/directory
+#     email: seu-email@exemplo.com
+#     privateKeySecretRef:
+#       name: letsencrypt-staging-key
+#     solvers:
+#       - http01:
+#           ingress:
+#             ingressClassName: traefik
+
+---
+# ─── Let's Encrypt Produção (domínio real) ────────────────────────────────────
+# Descomente e ajuste quando o app estiver em produção com domínio público.
+#
+# apiVersion: cert-manager.io/v1
+# kind: ClusterIssuer
+# metadata:
+#   name: letsencrypt-prod
+# spec:
+#   acme:
+#     server: https://acme-v02.api.letsencrypt.org/directory
+#     email: seu-email@exemplo.com
+#     privateKeySecretRef:
+#       name: letsencrypt-prod-key
+#     solvers:
+#       - http01:
+#           ingress:
+#             ingressClassName: traefik

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
   - mariadb-service.yaml
   - app-deployment.yaml
   - app-service.yaml
+  - cert-manager-issuer.yaml
   - app-ingress.yaml

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,74 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # Oculta versão do Nginx
+    server_tokens off;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent"';
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    # ─── HTTP → HTTPS redirect ────────────────────────────────────────────────
+    server {
+        listen      80;
+        server_name _;
+        return 301  https://$host$request_uri;
+    }
+
+    # ─── HTTPS ────────────────────────────────────────────────────────────────
+    server {
+        listen 443 ssl;
+        server_name _;
+
+        ssl_certificate     /etc/nginx/certs/cert.pem;
+        ssl_certificate_key /etc/nginx/certs/key.pem;
+
+        # Apenas TLS 1.2 e 1.3; cifras seguras (OWASP TLS Cheat Sheet)
+        ssl_protocols             TLSv1.2 TLSv1.3;
+        ssl_ciphers               ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256;
+        ssl_prefer_server_ciphers off;
+        ssl_session_cache         shared:SSL:10m;
+        ssl_session_timeout       1d;
+        ssl_session_tickets       off;
+
+        # ─── Security headers ─────────────────────────────────────────────────
+        add_header Strict-Transport-Security  "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Frame-Options            SAMEORIGIN always;
+        add_header X-Content-Type-Options     nosniff always;
+        add_header Referrer-Policy            "strict-origin-when-cross-origin" always;
+
+        # ─── Proxy para o Spring Boot ─────────────────────────────────────────
+        location / {
+            proxy_pass              http://app:8080;
+            proxy_http_version      1.1;
+            proxy_set_header        Host              $host;
+            proxy_set_header        X-Real-IP         $remote_addr;
+            proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Forwarded-Proto $scheme;
+            proxy_set_header        X-Forwarded-Port  $server_port;
+            proxy_connect_timeout   30s;
+            proxy_read_timeout      60s;
+            proxy_send_timeout      60s;
+
+            # Desativa buffering para SSE / streaming (se usado no futuro)
+            proxy_buffering         on;
+            proxy_buffer_size       4k;
+            proxy_buffers           8 4k;
+        }
+    }
+}

--- a/scripts/generate-dev-certs.sh
+++ b/scripts/generate-dev-certs.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# ─── Geração de certificado autoassinado para desenvolvimento ─────────────────
+# Gera cert.pem + key.pem em nginx/certs/ para uso local com o Nginx.
+# NÃO use em produção; substitua por certificados reais ou cert-manager.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CERTS_DIR="$SCRIPT_DIR/../nginx/certs"
+
+mkdir -p "$CERTS_DIR"
+
+openssl req -x509 -nodes -days 365 \
+  -newkey rsa:2048 \
+  -keyout "$CERTS_DIR/key.pem" \
+  -out    "$CERTS_DIR/cert.pem" \
+  -subj   "/CN=localhost/O=Brewer Dev/C=BR" \
+  -addext "subjectAltName=DNS:localhost,DNS:brewer.local,IP:127.0.0.1"
+
+chmod 600 "$CERTS_DIR/key.pem"
+chmod 644 "$CERTS_DIR/cert.pem"
+
+echo "Certificado autoassinado gerado em $CERTS_DIR"
+echo "  cert.pem  — certificado público"
+echo "  key.pem   — chave privada (não versionar)"

--- a/scripts/trust-dev-ca.sh
+++ b/scripts/trust-dev-ca.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# ─── Instala a CA local do brewer no trust store do sistema ───────────────────
+# Após rodar este script, browsers baseados em NSS (Chrome, Chromium, Firefox)
+# e ferramentas de linha de comando (curl, wget) confiarão automaticamente no
+# certificado de https://brewer.local.
+#
+# Requer: kubectl, openssl, sudo
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+CA_CERT="/tmp/brewer-local-ca.crt"
+CA_NAME="brewer-local-ca"
+
+echo "==> Aguardando o certificado da CA ser emitido pelo cert-manager..."
+kubectl wait certificate/brewer-local-ca \
+  --namespace cert-manager \
+  --for=condition=ready \
+  --timeout=60s
+
+echo "==> Exportando certificado da CA..."
+kubectl get secret brewer-local-ca-tls \
+  --namespace cert-manager \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d > "$CA_CERT"
+
+echo "==> Informações do certificado:"
+openssl x509 -in "$CA_CERT" -noout -subject -issuer -dates
+
+# ─── Instalação no trust store do sistema (Linux) ────────────────────────────
+if command -v update-ca-certificates &>/dev/null || [ -x /usr/sbin/update-ca-certificates ]; then
+  UPDATE_CA_CERTS="${UPDATE_CA_CERTS:-/usr/sbin/update-ca-certificates}"
+  # Debian / Ubuntu / Raspbian
+  sudo cp "$CA_CERT" "/usr/local/share/ca-certificates/${CA_NAME}.crt"
+  sudo "$UPDATE_CA_CERTS"
+  echo "==> CA instalada via update-ca-certificates."
+elif command -v update-ca-trust &>/dev/null || [ -x /usr/sbin/update-ca-trust ]; then
+  # RHEL / CentOS / Fedora
+  sudo cp "$CA_CERT" "/etc/pki/ca-trust/source/anchors/${CA_NAME}.crt"
+  sudo /usr/sbin/update-ca-trust extract
+  echo "==> CA instalada via update-ca-trust."
+else
+  echo "AVISO: gerenciador de CA não reconhecido. Instale manualmente:"
+  echo "  $CA_CERT"
+fi
+
+# ─── Instalação no NSS DB (Chrome / Chromium / Edge no Linux) ────────────────
+CERTUTIL_BIN=$(command -v certutil 2>/dev/null || echo /usr/bin/certutil)
+if [ -x "$CERTUTIL_BIN" ]; then
+  for NSS_DB in \
+    "$HOME/.pki/nssdb" \
+    "$HOME/snap/chromium/current/.pki/nssdb" \
+    "$HOME/.mozilla/firefox/"*.default-release; do
+    if [ -d "$NSS_DB" ]; then
+      "$CERTUTIL_BIN" -d "sql:$NSS_DB" -A -n "$CA_NAME" -t "C,," -i "$CA_CERT" 2>/dev/null && \
+        echo "==> CA adicionada ao NSS DB: $NSS_DB" || true
+    fi
+  done
+else
+  echo "AVISO: 'certutil' não encontrado. Para instalar no Chrome/Chromium:"
+  echo "  sudo apt-get install -y libnss3-tools"
+  echo "  certutil -d sql:\$HOME/.pki/nssdb -A -n brewer-local-ca -t 'C,,' -i $CA_CERT"
+fi
+
+rm -f "$CA_CERT"
+echo ""
+echo "Concluído. Reinicie o browser para que as mudanças tenham efeito."


### PR DESCRIPTION
## O que foi feito

Configura HTTPS para os dois ambientes de deploy do projeto.

---

### Docker Compose — Nginx reverse proxy

- Novo serviço `nginx` (imagem `nginx:1.27-alpine`) nas portas **80/443**
- Redirect automático HTTP → HTTPS
- TLS 1.2/1.3 com cifras seguras (OWASP TLS Cheat Sheet)
- Headers de segurança: `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`
- Proxy reverso para `app:8080` com headers `X-Forwarded-*` corretos
- `scripts/generate-dev-certs.sh` — gera certificado autoassinado para dev local
- Chaves privadas (`nginx/certs/`) adicionadas ao `.gitignore`

### Kubernetes (K3s + Traefik + cert-manager)

Estratégia de CA local em 3 passos (`k8s/cert-manager-issuer.yaml`):

```
selfsigned-bootstrapper (ClusterIssuer)
  └─► brewer-local-ca (Certificate, namespace cert-manager)
        └─► brewer-local-ca-issuer (ClusterIssuer)
              └─► brewer-tls (Certificate, namespace brewer)
```

- `app-ingress.yaml` atualizado com seção `tls` e anotações `cert-manager` + Traefik
- Templates ACME comentados para Let's Encrypt (staging e prod) prontos para produção
- `scripts/trust-dev-ca.sh` — exporta a CA do cluster e instala no trust store do sistema (`update-ca-certificates`) e no NSS DB do browser (`certutil`)

---

### Pré-requisitos

**Docker Compose:**
```bash
./scripts/generate-dev-certs.sh
docker compose up -d
```

**Kubernetes:**
```bash
kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
kubectl wait --namespace cert-manager --for=condition=ready pod \
  --selector=app.kubernetes.io/instance=cert-manager --timeout=120s
kubectl apply -k k8s/
./scripts/trust-dev-ca.sh   # instala CA no sistema/browser
```