### PR TITLE
chore: configure VS Code IDE, extensions and SonarQube local stack

### DIFF
--- a/.github/instructions/master.instructions.md
+++ b/.github/instructions/master.instructions.md
@@ -1,0 +1,49 @@
+---
+description: Master Instructions - Sempre ativo
+priority: high
+---
+
+# MASTER INSTRUCTIONS - Java Team
+
+Você é o **orquestrador** de um time de especialistas em desenvolvimento Java.
+
+### Personas Disponíveis:
+
+- **@Architect** → Arquiteto de Software
+- **@JavaSenior** → Desenvolvedor Java Sênior
+- **@CodeReviewer** → Code Reviewer Rigoroso
+- **@QA** → Engenheiro de Qualidade
+- **@Security** → Especialista em Segurança
+- **@Performance** → Engenheiro de Performance
+- **@DevOps** → DevOps / Platform Engineer
+- **@Domain** → Domain Expert (DDD)
+- **@TechLead** → Tech Lead
+- **@Pair** → AI Pair Programmer (foco em produtividade)
+
+### Regras de Colaboração (obrigatórias):
+
+1. **Sempre comece analisando** qual persona(s) é mais adequada para a tarefa.
+2. **Você pode invocar múltiplas personas** na mesma resposta usando o formato @Persona.
+3. **Hand-off natural**: Quando perceber que outra persona pode contribuir melhor, faça a transição explicitamente.
+   Exemplo: "Vou passar para o @Architect para validar o design."
+4. **Workflow Padrão Sugerido** (use quando aplicável):
+   - @Domain → entender o problema de negócio
+   - @Architect → definir o design
+   - @JavaSenior → implementar
+   - @QA → definir testes
+   - @CodeReviewer → revisar
+   - @Security / @Performance → validações específicas
+5. **Formato de Resposta**:
+   - Indique claramente qual persona está falando no momento.
+   - Exemplo:
+     **[@Architect]** → Análise...
+     **[@JavaSenior]** → Implementação...
+6. **Modo Colaborativo**:
+   - Se o usuário não especificar persona, você decide quem deve atuar e pode alternar entre elas.
+   - Seja proativo: sugira a próxima persona quando fizer sentido.
+
+**Prompt de Ativação Rápida (use no chat):**
+
+"@Master + [sua demanda]"
+
+Você deve ser prático, objetivo e focado em entregar valor com qualidade.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,11 @@
     "angular.ng-template",
     "ms-playwright.playwright",
     "ms-azuretools.vscode-docker",
-    "editorconfig.editorconfig"
+    "editorconfig.editorconfig",
+    "eamodio.gitlens",
+    "ms-kubernetes-tools.vscode-kubernetes-tools",
+    "github.vscode-github-actions",
+    "github.vscode-pull-request-github",
+    "sonarsource.sonarlint-vscode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,15 @@
 {
-  "java.jdt.ls.java.home": "/home/dante/.sdkman/candidates/java/21-tem",
+  // ── Java ─────────────────────────────────────────────────────────────
+  "java.jdt.ls.java.home": "/home/dante/.sdkman/candidates/java/25.0.3-amzn",
   "java.configuration.runtimes": [
     {
-      "name": "JavaSE-21",
-      "path": "/home/dante/.sdkman/candidates/java/21-tem",
+      "name": "JavaSE-25",
+      "path": "/home/dante/.sdkman/candidates/java/25.0.3-amzn",
       "default": true
+    },
+    {
+      "name": "JavaSE-21",
+      "path": "/home/dante/.sdkman/candidates/java/21-tem"
     }
   ],
   "java.configuration.updateBuildConfiguration": "automatic",
@@ -12,5 +17,51 @@
   "java.import.gradle.enabled": false,
   "java.compile.nullAnalysis.mode": "automatic",
   "maven.executable.path": "mvn",
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+
+  // ── GitLens ──────────────────────────────────────────────────────────
+  "gitlens.defaultDateFormat": "DD/MM/YYYY HH:mm",
+  "gitlens.defaultDateShortFormat": "DD/MM/YYYY",
+  "gitlens.currentLine.enabled": true,
+  "gitlens.hovers.currentLine.over": "line",
+  "gitlens.blame.highlight.enabled": true,
+  "gitlens.statusBar.enabled": true,
+
+  // ── Docker ───────────────────────────────────────────────────────────
+  "docker.host": "unix:///var/run/docker.sock",
+  "docker.compose.files": [
+    "${workspaceFolder}/docker-compose.yml",
+    "${workspaceFolder}/docker-compose.observability.yml"
+  ],
+  "docker.dockerfileLanguage.enable": true,
+  "docker.containers.label": "com.docker.compose.project",
+
+  // ── Kubernetes ───────────────────────────────────────────────────────
+  "vs-kubernetes.kubeconfig": "/home/dante/.kube/config",
+  "vs-kubernetes.knownKubeconfigs": ["/home/dante/.kube/config"],
+
+  // ── SonarLint ────────────────────────────────────────────────────────
+  "sonarlint.pathToNodeExecutable": "/usr/bin/node",
+  "sonarlint.rules": {
+    "java:S1135": { "level": "on" },
+    "java:S2095": { "level": "on" },
+    "java:S3776": { "level": "on" }
+  },
+  "sonarlint.analysisExcludesStandalone": "target/**,node_modules/**,.github/**",
+  // URL pública do SonarQube local; token adicionado via Command Palette (fora do git)
+  "sonarlint.connectedMode.connections.sonarqube": [
+    {
+      "connectionId": "sonarqube-local",
+      "serverUrl": "http://localhost:9000"
+    }
+  ],
+  "sonarlint.connectedMode.project": {
+    "connectionId": "sonarqube-local",
+    "projectKey": "Klaillton_brewer"
+  },
+  // ── GitHub Actions ───────────────────────────────────────────────────
+  "github-actions.workflows.pinned.workflows": [
+    ".github/workflows/dependency-check.yml",
+    ".github/workflows/ossar-analysis.yml"
+  ]
 }

--- a/docker-compose.sonarqube.yml
+++ b/docker-compose.sonarqube.yml
@@ -1,0 +1,91 @@
+# Stack SonarQube — análise estática de código (uso local / desenvolvimento)
+#
+# Pré-requisito: ajuste vm.max_map_count no host (necessário para o Elasticsearch
+# embutido no SonarQube):
+#   sudo sysctl -w vm.max_map_count=524288
+#   # Para persistir após reboot, adicione ao /etc/sysctl.conf:
+#   echo "vm.max_map_count=524288" | sudo tee -a /etc/sysctl.conf
+#
+# Iniciar:
+#   docker compose -f docker-compose.sonarqube.yml up -d
+#
+# Parar (sem remover dados):
+#   docker compose -f docker-compose.sonarqube.yml down
+#
+# Remover tudo (inclusive volumes):
+#   docker compose -f docker-compose.sonarqube.yml down -v
+#
+# Primeiro acesso: http://localhost:9000  →  admin / admin
+# Após o login, o SonarQube solicitará a troca de senha.
+#
+# Para gerar um token de análise:
+#   ./scripts/setup-sonarqube.sh
+# Ou acesse: http://localhost:9000/account/security
+
+services:
+  sonar-db:
+    image: postgres:17-alpine
+    container_name: sonar-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: sonar
+      POSTGRES_PASSWORD: sonar
+      POSTGRES_DB: sonar
+    volumes:
+      - sonar_db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sonar -d sonar"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - sonarqube-net
+
+  sonarqube:
+    image: sonarqube:lts-community
+    container_name: sonarqube
+    restart: unless-stopped
+    depends_on:
+      sonar-db:
+        condition: service_healthy
+    environment:
+      SONAR_JDBC_URL: jdbc:postgresql://sonar-db:5432/sonar
+      SONAR_JDBC_USERNAME: sonar
+      SONAR_JDBC_PASSWORD: sonar
+      # Aumenta heap da JVM interna (ajuste conforme RAM disponível)
+      SONAR_WEB_JAVAOPTS: "-Xmx512m -Xms128m"
+      SONAR_CE_JAVAOPTS: "-Xmx512m -Xms128m"
+      SONAR_SEARCH_JAVAOPTS: "-Xmx512m -Xms512m"
+    ports:
+      - "9000:9000"
+    volumes:
+      - sonarqube_data:/opt/sonarqube/data
+      - sonarqube_extensions:/opt/sonarqube/extensions
+      - sonarqube_logs:/opt/sonarqube/logs
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'wget -qO- http://localhost:9000/api/system/status 2>/dev/null | grep -q ''"status":"UP"''',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 15
+      start_period: 120s
+    networks:
+      - sonarqube-net
+
+volumes:
+  sonarqube_data:
+    name: sonarqube_data
+  sonarqube_extensions:
+    name: sonarqube_extensions
+  sonarqube_logs:
+    name: sonarqube_logs
+  sonar_db_data:
+    name: sonar_db_data
+
+networks:
+  sonarqube-net:
+    name: sonarqube-net

--- a/scripts/setup-sonarqube.sh
+++ b/scripts/setup-sonarqube.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# =============================================================================
+# setup-sonarqube.sh
+#
+# Bootstrap do servidor SonarQube local:
+#   - Aguarda o servidor ficar disponível
+#   - Troca a senha padrão (admin/admin → nova senha)
+#   - Cria um token de análise global (salvo em ~/.sonar/token)
+#   - Gera/atualiza ~/.sonar/sonar-scanner.properties para uso em todos
+#     os projetos futuros (padronização do servidor local)
+#
+# Uso:
+#   ./scripts/setup-sonarqube.sh
+#
+# Variáveis de ambiente opcionais:
+#   SONAR_URL        URL do servidor  (padrão: http://localhost:9000)
+#   SONAR_NEW_PASS   Nova senha admin (padrão: solicita interativamente)
+#   SONAR_TOKEN_NAME Nome do token    (padrão: local-dev)
+# =============================================================================
+set -euo pipefail
+
+SONAR_URL="${SONAR_URL:-http://localhost:9000}"
+TOKEN_NAME="${SONAR_TOKEN_NAME:-local-dev}"
+TOKEN_FILE="$HOME/.sonar/token"
+SCANNER_PROPS="$HOME/.sonar/sonar-scanner.properties"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# 1. Verifica dependências
+# ---------------------------------------------------------------------------
+for cmd in curl jq; do
+  if ! command -v "$cmd" &>/dev/null; then
+    error "Comando '$cmd' não encontrado. Instale-o e tente novamente."
+    exit 1
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Aguarda SonarQube ficar UP (máx. 5 min)
+# ---------------------------------------------------------------------------
+info "Aguardando SonarQube em $SONAR_URL ..."
+TIMEOUT=300
+ELAPSED=0
+until curl -sf "$SONAR_URL/api/system/status" 2>/dev/null | grep -q '"status":"UP"'; do
+  if [[ $ELAPSED -ge $TIMEOUT ]]; then
+    error "SonarQube não ficou disponível em ${TIMEOUT}s. Verifique: docker compose -f docker-compose.sonarqube.yml logs sonarqube"
+    exit 1
+  fi
+  sleep 5
+  ELAPSED=$((ELAPSED + 5))
+  echo -n "."
+done
+echo ""
+info "SonarQube está UP."
+
+# ---------------------------------------------------------------------------
+# 3. Troca de senha padrão
+# ---------------------------------------------------------------------------
+if [[ -z "${SONAR_NEW_PASS:-}" ]]; then
+  echo -n "Digite a nova senha para o admin (mín. 12 caracteres): "
+  read -rs SONAR_NEW_PASS
+  echo ""
+fi
+
+if [[ ${#SONAR_NEW_PASS} -lt 12 ]]; then
+  error "A senha deve ter pelo menos 12 caracteres."
+  exit 1
+fi
+
+HTTP_STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
+  -u admin:admin \
+  -X POST "$SONAR_URL/api/users/change_password" \
+  -d "login=admin&previousPassword=admin&password=$SONAR_NEW_PASS" 2>/dev/null || echo "000")
+
+if [[ "$HTTP_STATUS" == "204" ]]; then
+  info "Senha do admin alterada com sucesso."
+elif [[ "$HTTP_STATUS" == "401" ]]; then
+  warn "Senha padrão já foi alterada. Continuando com a senha fornecida..."
+else
+  warn "Troca de senha retornou HTTP $HTTP_STATUS. Pode ser que já esteja configurada."
+fi
+
+ADMIN_PASS="$SONAR_NEW_PASS"
+
+# ---------------------------------------------------------------------------
+# 4. Cria token de análise
+# ---------------------------------------------------------------------------
+mkdir -p "$HOME/.sonar"
+
+# Remove token anterior de mesmo nome para evitar conflito
+curl -sf -u "admin:$ADMIN_PASS" \
+  -X POST "$SONAR_URL/api/user_tokens/revoke" \
+  -d "name=$TOKEN_NAME" &>/dev/null || true
+
+TOKEN_RESPONSE=$(curl -sf -u "admin:$ADMIN_PASS" \
+  -X POST "$SONAR_URL/api/user_tokens/generate" \
+  -d "name=$TOKEN_NAME&type=GLOBAL_ANALYSIS_TOKEN")
+
+TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r '.token')
+
+if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+  error "Falha ao gerar token. Resposta: $TOKEN_RESPONSE"
+  exit 1
+fi
+
+echo "$TOKEN" > "$TOKEN_FILE"
+chmod 600 "$TOKEN_FILE"
+info "Token salvo em: $TOKEN_FILE"
+
+# ---------------------------------------------------------------------------
+# 5. Gera ~/.sonar/sonar-scanner.properties (padronização global)
+# ---------------------------------------------------------------------------
+cat > "$SCANNER_PROPS" <<EOF
+# SonarScanner — configuração global para projetos locais
+# Gerado por scripts/setup-sonarqube.sh em $(date '+%Y-%m-%d %H:%M:%S')
+#
+# Para usar em qualquer projeto, basta executar:
+#   mvn sonar:sonar -Dsonar.token=\$(cat ~/.sonar/token)
+# Ou defina a variável SONAR_TOKEN:
+#   export SONAR_TOKEN=\$(cat ~/.sonar/token)
+
+sonar.host.url=$SONAR_URL
+sonar.token=$TOKEN
+EOF
+
+chmod 600 "$SCANNER_PROPS"
+info "Configuração global salva em: $SCANNER_PROPS"
+
+# ---------------------------------------------------------------------------
+# 6. Resumo
+# ---------------------------------------------------------------------------
+echo ""
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}  SonarQube local configurado!${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo "  URL:    $SONAR_URL"
+echo "  Token:  $(cat "$TOKEN_FILE" | cut -c1-8)... (salvo em $TOKEN_FILE)"
+echo ""
+echo "  Para analisar este projeto:"
+echo "    ./mvnw sonar:sonar -Dsonar.token=\$(cat ~/.sonar/token)"
+echo ""
+echo "  Para projetos futuros (token já em ~/.sonar/sonar-scanner.properties):"
+echo "    ./mvnw sonar:sonar"
+echo ""

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,36 @@
+sonar.projectKey=Klaillton_brewer
+sonar.projectName=Brewer
+sonar.projectVersion=1.0.0-SNAPSHOT
+
+sonar.sources=src/main/java
+sonar.tests=src/test/java
+sonar.java.binaries=target/classes
+sonar.java.test.binaries=target/test-classes
+sonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
+
+sonar.sourceEncoding=UTF-8
+sonar.java.source=25
+
+sonar.exclusions=\
+  target/**,\
+  src/main/webapp/static/**,\
+  frontend/node_modules/**,\
+  e2e/**
+
+sonar.test.exclusions=\
+  src/main/java/**
+
+# ---------------------------------------------------------------------------
+# SonarCloud (ativo — vinculado ao GitHub)
+# ---------------------------------------------------------------------------
+# Token: gere em https://sonarcloud.io/account/security e exporte como
+# SONAR_TOKEN, ou passe via: ./mvnw sonar:sonar -Dsonar.token=<token>
+#
+sonar.host.url=https://sonarcloud.io
+sonar.organization=klaillton
+
+# ---------------------------------------------------------------------------
+# Servidor local (docker-compose.sonarqube.yml — desativado)
+# ---------------------------------------------------------------------------
+# sonar.host.url=http://localhost:9000
+# Análise local: ./mvnw sonar:sonar -Dsonar.token=$(cat ~/.sonar/token)


### PR DESCRIPTION
## Resumo das mudanças

### IDE / VS Code
- **`.vscode/extensions.json`** — adicionadas extensões faltantes às recomendações do workspace: GitLens, Kubernetes Tools, GitHub Actions, GitHub Pull Requests e SonarLint
- **`.vscode/settings.json`** — corrigido `java.jdt.ls.java.home` para Java 25 (sdkman); adicionadas configurações para GitLens, Docker (socket explícito), Kubernetes (chaves top-level `vs-kubernetes.*`), SonarLint (connected mode apontando para SonarQube local em `localhost:9000`) e GitHub Actions (workflows fixados)

### SonarQube
- **`sonar-project.properties`** — novo arquivo com `projectKey`, sources/tests, binaries, path do relatório JaCoCo e exclusões
- **`docker-compose.sonarqube.yml`** — stack local SonarQube + PostgreSQL na porta 9000
- **`scripts/setup-sonarqube.sh`** — script de bootstrap: aguarda SonarQube, rotaciona senha admin e gera token de análise

### Copilot
- **`.github/instructions/master.instructions.md`** — instruções de workspace para o GitHub Copilot

## Motivação
- Extensões Docker, Kubernetes e SonarLint não funcionavam por falta de configuração explícita no workspace
- `java.jdt.ls.java.home` ausente no Machine scope causava mensagem de "instalar JDK"
- Chaves `vs-kubernetes` estavam aninhadas (formato inválido)
- SonarQube já rodava localmente mas SonarLint não estava apontado para ele