### PR TITLE
Add automatic deploy to devserverpi (k3s) workflow

### DIFF
--- a/.github/workflows/deploy-to-pi.yml
+++ b/.github/workflows/deploy-to-pi.yml
@@ -12,6 +12,9 @@ on:
       - ".github/workflows/deploy-to-pi.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-to-pi.yml
+++ b/.github/workflows/deploy-to-pi.yml
@@ -29,7 +29,7 @@ jobs:
           username: ${{ secrets.DEVPI_USER }}
           key: ${{ secrets.DEVPI_SSH_PRIVATE_KEY }}
           script: |
-            set -euo pipefail
+            bash -euo pipefail <<'BASH'
             echo "Deploying brewer app via k3s on Pi..."
             cd /home/dante/brewer
 
@@ -42,3 +42,4 @@ jobs:
 
             echo "Brewer deploy completed at $(date)"
             kubectl get pods -n brewer
+            BASH

--- a/.github/workflows/deploy-to-pi.yml
+++ b/.github/workflows/deploy-to-pi.yml
@@ -18,6 +18,9 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-to-pi
+      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-to-pi.yml
+++ b/.github/workflows/deploy-to-pi.yml
@@ -1,0 +1,41 @@
+name: Deploy brewer to devserverpi (k3s)
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - "Dockerfile"
+      - "src/**"
+      - "pom.xml"
+      - "k8s/**"
+      - "scripts/**"
+      - ".github/workflows/deploy-to-pi.yml"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to Raspberry Pi (run existing deploy.sh)
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEVPI_HOST }}
+          username: ${{ secrets.DEVPI_USER }}
+          key: ${{ secrets.DEVPI_SSH_PRIVATE_KEY }}
+          script: |
+            set -euo pipefail
+            echo "Deploying brewer app via k3s on Pi..."
+            cd /home/dante/brewer
+
+            git fetch origin
+            git checkout master
+            git pull --ff-only origin master
+
+            # Run the official deploy script (builds image on Pi + applies k8s)
+            ./deploy.sh
+
+            echo "Brewer deploy completed at $(date)"
+            kubectl get pods -n brewer


### PR DESCRIPTION
Adds .github/workflows/deploy-to-pi.yml that triggers on relevant changes to master and runs the existing `./deploy.sh` on the Pi via SSH (using the same secrets as devstack-infra).

This enables automatic deploys of the brewer app to the Raspberry Pi when pushing to master.

Requires the following repo secrets to be set:
- DEVPI_HOST
- DEVPI_USER
- DEVPI_SSH_PRIVATE_KEY

(Already used by the devstack-infra workflow.)